### PR TITLE
Patch program interpreter and rpath

### DIFF
--- a/bootloader/SConscript
+++ b/bootloader/SConscript
@@ -10,6 +10,7 @@ bootloader = env.Program(
     source = [
         'error.c',
         'main.c',
+        'mmap.c',
     ],
     LIBS = ['tar'],
 )

--- a/bootloader/SConscript
+++ b/bootloader/SConscript
@@ -11,6 +11,7 @@ bootloader = env.Program(
         'error.c',
         'main.c',
         'mmap.c',
+        'util.c',
     ],
     LIBS = ['tar'],
 )

--- a/bootloader/SConscript
+++ b/bootloader/SConscript
@@ -7,7 +7,10 @@ env.Append(
 
 bootloader = env.Program(
     target = 'bootloader',
-    source = ['main.c'],
+    source = [
+        'error.c',
+        'main.c',
+    ],
     LIBS = ['tar'],
 )
 

--- a/bootloader/error.c
+++ b/bootloader/error.c
@@ -1,0 +1,27 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+#include "error.h"
+
+void
+error(int status, int errnum, const char *format, ...)
+{
+    fflush(stdout);
+
+    fprintf(stderr, "%s: ", program_invocation_short_name);
+
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    va_end(ap);
+
+    if (errnum)
+        fprintf(stderr, ": %s", strerror(errnum));
+    fprintf(stderr, "\n");
+
+    if (status)
+        exit(status);
+}

--- a/bootloader/error.h
+++ b/bootloader/error.h
@@ -1,0 +1,6 @@
+#ifndef ERROR_H
+#define ERROR_H
+
+void error(int status, int errnum, const char *format, ...);
+
+#endif /* ERROR_H */

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -2,7 +2,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <stdarg.h>
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
@@ -12,6 +11,7 @@
 #include <sys/mman.h>
 #include <elf.h>
 #include <libtar.h>
+#include "error.h"
 
 #define ARCHIVE_SECTION         ".staticx.archive"
 #define INTERP_FILENAME         ".staticx.interp"
@@ -28,25 +28,6 @@
 #define Elf_Ehdr    Elf64_Ehdr
 #define Elf_Shdr    Elf64_Shdr
 
-static void
-error(int status, int errnum, const char *format, ...)
-{
-    fflush(stdout);
-
-    fprintf(stderr, "%s: ", program_invocation_short_name);
-
-    va_list ap;
-    va_start(ap, format);
-    vfprintf(stderr, format, ap);
-    va_end(ap);
-
-    if (errnum)
-        fprintf(stderr, ": %s", strerror(errnum));
-    fprintf(stderr, "\n");
-
-    if (status)
-        exit(status);
-}
 
 static inline const void *
 cptr_add(const void *p, size_t off)

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -234,19 +234,16 @@ create_tmpdir(void)
 }
 
 static char **
-make_argv(int orig_argc, char **orig_argv)
+make_argv(int orig_argc, char **orig_argv, char *argv0)
 {
     /**
      * Generate an argv to execute the user app:
      * ./.staticx.interp --library-path . ./.staticx.prog */
-    int len = 1 + 2 + 1 + (orig_argc-1) + 1;
+    int len = 1 + (orig_argc-1) + 1;
     char **argv = calloc(len, sizeof(char*));
 
     int w = 0;
-    argv[w++] = path_join(m_homedir, INTERP_FILENAME);
-    argv[w++] = "--library-path";
-    argv[w++] = strdup(m_homedir);
-    argv[w++] = path_join(m_homedir, PROG_FILENAME);
+    argv[w++] = argv0;
 
     for (int i=1; i < orig_argc; i++) {
         argv[w++] = orig_argv[i];
@@ -266,7 +263,7 @@ run_app(int argc, char **argv)
     set_interp(prog_path, interp_path);
     free(interp_path);
 
-    char **new_argv = make_argv(argc, argv);
+    char **new_argv = make_argv(argc, argv, prog_path);
 
     debug_printf("New argv:\n");
     for (int i=0; ; i++) {

--- a/bootloader/mmap.c
+++ b/bootloader/mmap.c
@@ -1,0 +1,50 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include "error.h"
+#include "mmap.h"
+
+struct map *
+mmap_file(const char *path, bool readonly)
+{
+    struct map *map;
+
+    if ((map = malloc(sizeof(*map))) == NULL)
+        error(2, 0, "Failed to allocate map struture");
+
+    int oflags = readonly ? O_RDONLY : O_RDWR;
+    if ((map->fd = open(path, oflags)) < 0)
+        error(2, errno, "Failed to open %s", path);
+
+    struct stat st;
+    if (fstat(map->fd, &st) < 0)
+        error(2, errno, "Failed to stat %s", path);
+    map->size = st.st_size;
+
+    int prot = readonly ? PROT_READ : PROT_READ|PROT_WRITE;
+    map->map = mmap(NULL, map->size, prot, MAP_SHARED, map->fd, 0);
+    if (map->map == MAP_FAILED)
+        error(2, errno, "Failed to mmap %s", path);
+
+    return map;
+}
+
+void
+unmap_file(struct map *map)
+{
+    if (map->map) {
+        munmap(map->map, map->size);
+        map->map = NULL;
+    }
+
+    if (map->fd != -1) {
+        close(map->fd);
+        map->fd = -1;
+    }
+
+    free(map);
+}

--- a/bootloader/mmap.h
+++ b/bootloader/mmap.h
@@ -1,0 +1,19 @@
+#ifndef MMAP_H
+#define MMAP_H
+
+#include <stdbool.h>
+
+struct map
+{
+    int fd;
+    size_t size;
+    void *map;
+};
+
+struct map *
+mmap_file(const char *path, bool readonly);
+
+void
+unmap_file(struct map *map);
+
+#endif /* MMAP_H */

--- a/bootloader/util.h
+++ b/bootloader/util.h
@@ -1,0 +1,6 @@
+#ifndef UTIL_H
+#define UTIL_H
+
+char *readlinka(const char *path);
+
+#endif /* UTIL_H */

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import argparse
 import sys
+import logging
 
 from .api import generate
 from .errors import Error
@@ -16,12 +17,18 @@ def parse_args():
     ap.add_argument('-V', '--version', action='version',
             version = '%(prog)s ' + __version__)
 
+    ap.add_argument('--loglevel', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+            default='WARNING',
+            help = 'Set the logging level (default: %(default)s)')
+
     ap.add_argument('--bootloader',
             help = argparse.SUPPRESS)
     return ap.parse_args()
 
 def main():
     args = parse_args()
+    logging.basicConfig(level=args.loglevel)
+
     try:
         generate(args.prog, args.output, args.bootloader)
     except Error as e:

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -1,0 +1,6 @@
+import os
+
+def make_executable(path):
+    mode = os.stat(path).st_mode
+    mode |= (mode & 0o444) >> 2    # copy R bits to X
+    os.chmod(path, mode)


### PR DESCRIPTION
By patching the program interpreter and rpath at runtime (to point to our extracted archive directory), we can now run the program directly, instead of launching via the interpreter. This lets `/proc/self/exe` actually point to the application, which is important for applications (like those built by PyInstaller) which need to access their executable file.