### PR TITLE
Updating util.c to include required define for ntfw inclusion

### DIFF
--- a/bootloader/util.c
+++ b/bootloader/util.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <stdio.h>          /* for remove(3) */
 #include <unistd.h>


### PR DESCRIPTION
ntfw is not included by default  when including ftw.h, a define is required before inclusion of ftw.h in order for gcc to resolve the symbol.

Note, this change is still needed despite changing GCC flags for gnu99 compatibility in SConstruct