### PR TITLE
15 python27 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ The following external tools need to be installed to run StaticX:
 - `ldd` - Part of GNU C Library
 - `readelf` - Part of binutils
 - `objcopy` - Part of binutils
-- [`patchelf`](patchelf)
+- [`patchelf`][patchelf]
    - Packages available for Debian 8+, Fedora 14+, others
+   - install with `pip install patchelf-wrapper`
 
 The following additional tools must be installed to build StaticX from source:
 - `scons`
-- [`musl-libc`](musl-libc) *(optional)*
+- [`musl-libc`][musl-libc] *(optional)*
 
 
 ## Installation
@@ -32,6 +33,25 @@ environment variable to your `musl-gcc` wrapper path:
 ```
 sudo CC=/usr/local/musl/bin/musl-gcc pip3 install https://github.com/JonathonReinhart/staticx/archive/master.zip
 ```
+### Building from cloned repository
+
+- Ensure dependencies are installed as above.
+- Change to the root repository directory
+- Run `scons`
+- Run `python setup.py install`
+
+## Usage
+
+Basic wrapping of an executable
+```
+staticx /path/to/exe /path/to/output
+```
+
+Including additional library files with the package (any number can be specified by repeating the -l option)
+```
+staticx -l /path/to/fancy/library /path/to/exe /path/to/output
+```
+
 
 
 [patchelf]: https://nixos.org/patchelf.html

--- a/bootloader/util.c
+++ b/bootloader/util.c
@@ -1,3 +1,4 @@
+#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <stdio.h>          /* for remove(3) */
 #include <unistd.h>

--- a/bootloader/util.c
+++ b/bootloader/util.c
@@ -1,4 +1,3 @@
-#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <stdio.h>          /* for remove(3) */
 #include <unistd.h>

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -24,7 +24,7 @@ MAX_RPATH_LEN = 256
 def get_shobj_deps(path):
     try:
         output = subprocess.check_output(['ldd', path])
-    except FileNotFoundError:
+    except OSError:
         raise MissingToolError('ldd', 'binutils')
     except subprocess.CalledProcessError as e:
         raise ToolError('ldd')
@@ -50,7 +50,7 @@ def readelf(path, *args):
     args = ['readelf'] + list(args) + [path]
     try:
         output = subprocess.check_output(args)
-    except FileNotFoundError:
+    except OSError:
         raise MissingToolError('readelf', 'binutils')
     except subprocess.CalledProcessError as e:
         raise ToolError('readelf')
@@ -84,7 +84,7 @@ def patch_elf(path, interpreter=None, rpath=None, force_rpath=False):
     logging.debug("Running " + str(args))
     try:
         output = subprocess.check_call(args)
-    except FileNotFoundError:
+    except OSError:
         raise MissingToolError('patchelf', 'patchelf')
     except subprocess.CalledProcessError as e:
         raise ToolError('patchelf')
@@ -170,6 +170,9 @@ def generate(prog, output, libs=None, bootloader=None):
 
     # First, learn things about the original program
     orig_interp = get_prog_interp(prog)
+
+    # set tmpoutput to None, so as not to confuse python during an error where the output dir isn't set
+    tmpoutput = None
 
     # Now modify a copy of the user prog
     tmpprog = _copy_to_tempfile(prog, prefix='staticx-prog-', delete=False).name

--- a/staticx/errors.py
+++ b/staticx/errors.py
@@ -10,13 +10,13 @@ class InternalError(Error):
 class ToolError(Error):
     """An external tool indicated an error"""
     def __init__(self, program, message=None):
-        super().__init__(message or "'{}' failed".format(program))
+        super(ToolError,self).__init__(message or "'{}' failed".format(program))
         self.program = program
 
 class MissingToolError(Error):
     """A required external tool is missing"""
     def __init__(self, program, package):
-        super().__init__("Couldn't find '{}'. Is '{}' installed?".format(
+        super(MissingToolError, self).__init__("Couldn't find '{}'. Is '{}' installed?".format(
             program, package))
         self.program = program
         self.package = package


### PR DESCRIPTION
Resolving issue 15-- compatibility with python 2.7.  

Namely, reverting to the older OSError exception instead of the newer FileNotFoundError, and reverting to an older protocol for calling super class constructors for initialization

Also includes some unrelated Readme.MD changes. sorry for the mess.