### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+dist: trusty
+sudo: required
+serivces:
+  - docker
+
+language: python
+python:
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev
+
+matrix:
+  allow_failures:
+    - python: "nightly"
+
+addons:
+  apt:
+    packages:
+      - musl
+      - musl-dev
+      - musl-tools
+
+env:
+  global:
+    - CC=musl-gcc
+
+before_script:
+  - pip install wheel
+
+script:
+  - python setup.py bdist_wheel
+  - pip install dist/staticx-*-py2.py3-none-any.whl
+
+  - staticx --version
+  - staticx $(which date) date.staticx
+  - ./date.staticx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+patchelf-wrapper


### PR DESCRIPTION
This enables basic building + testing on Travis. Future work will add unit tests and targeted system tests.