### PR TITLE
Improve setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /build/
 .sconsign.dblite
 *.pyc
+
+# Setup.py stuff
+/dist/
+*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/build/
 .sconsign.dblite
 *.pyc
+/scons_build/
 
 # Setup.py stuff
+/build/
 /dist/
 *.egg-info

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+graft bootloader
+graft libtar
+include SConstruct

--- a/SConstruct
+++ b/SConstruct
@@ -8,8 +8,8 @@ env = Environment(
     ],
     CPPPATH = ['#libtar'],
 
-    BUILD_ROOT = '#build',
-    LIBDIR = '#build/lib',
+    BUILD_ROOT = '#scons_build',
+    LIBDIR = '$BUILD_ROOT/lib',
     LIBPATH = '$LIBDIR'
 )
 

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,6 @@ class build_py_hook(build_py):
     pass
 cmdclass_hooks['build_py'] = build_py_hook
 
-@make_first
-class sdist_hook(sdist):
-    pass
-cmdclass_hooks['sdist'] = sdist_hook
-
 try:
     from wheel.bdist_wheel import bdist_wheel
 except ImportError:


### PR DESCRIPTION
- Don't include prebuilt binaries in an `sdist` package
- Make SCons work better with setup.py