### PR TITLE
bootloader: Leave off FTW_MOUNT in nftw() call

### DIFF
--- a/bootloader/util.c
+++ b/bootloader/util.c
@@ -74,7 +74,13 @@ int
 remove_tree(const char *pathname)
 {
     int max_open_fd = 20;
-    int flags = FTW_DEPTH | FTW_MOUNT | FTW_PHYS;
+
+    /**
+     * Musl libc < 1.0.0 had a bug where FTW_MOUNT flag prevented walking any
+     * directories at all. We don't really need it, so just leave it off.
+     * See https://github.com/JonathonReinhart/staticx/issues/25
+     */
+    int flags = FTW_DEPTH | /* FTW_MOUNT | */ FTW_PHYS;
 
     errno = 0;
     return nftw(pathname, remove_tree_fn, max_open_fd, flags);


### PR DESCRIPTION
Travis currently runs ubuntu 14.04 which includes musl 0.9.15-1 which
exhibits a bug where FTW_MOUNT causes problems. We'll just leave off the
flag (which we don't really need anyway) to work on older versions of
musl.

This fixes #25