### PR TITLE
ci: Unset CC before installing Python packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     - TEST_DOCKER_IMAGE=centos:5
   matrix:
-  - BOOTLOADER_CC=musl-gcc     # Default to musl libc
+  - CC=musl-gcc     # Default to musl libc
 matrix:
   include:
     - python: "2.7"
@@ -19,7 +19,7 @@ matrix:
 
     # Test using glibc
     - python: "3.5"
-      env: BOOTLOADER_CC=
+      env: CC=
 
     - python: "3.5-dev" # 3.5 development branch
     - python: "nightly" # currently points to 3.6-dev
@@ -34,12 +34,16 @@ addons:
       - musl-tools
       - liblzma-dev
 
+install:
+  # Unset CC before installing Python packages - see #44
+  - env -u CC   pip install -r requirements.txt
+
 before_script:
   - docker pull $TEST_DOCKER_IMAGE
 
 script:
   # Build and install a wheel
-  - CC=${BOOTLOADER_CC} python setup.py bdist_wheel
+  - python setup.py bdist_wheel
   - pip install dist/staticx-*-py2.py3-none-any.whl
   - staticx --version
 


### PR DESCRIPTION
This is a better fix for #44, ensuring CC doesn't interfere with
installing Python packages needed.

1a95f89463370f1495d11190a2da73108ce3868f didn't help.