### PR TITLE
Check user app bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Detect if user app is a different machine type than the bootloader ([#56])
+
+
 ## [0.5.0] - 2017-07-16
 ### Added
 - Added `--strip` option to strip binaries while adding to archive ([#39])
@@ -68,3 +73,4 @@ Initial release
 [#46]: https://github.com/JonathonReinhart/staticx/pull/46
 [#52]: https://github.com/JonathonReinhart/staticx/pull/52
 [#54]: https://github.com/JonathonReinhart/staticx/pull/54
+[#56]: https://github.com/JonathonReinhart/staticx/pull/56

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyinstaller; (python_version == '2.7') or (python_version >= '3.3' and python_ve
 scuba
 wheel
 backports.lzma; (python_version < '3.3')
+pyelftools

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup(
         ]
     },
     install_requires = [
+        'pyelftools',
     ],
 
     # http://stackoverflow.com/questions/17806485

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -58,6 +58,16 @@ def _locate_bootloader():
         raise InternalError("bootloader not found at {}".format(blpath))
     return blpath
 
+
+def _check_bootloader_compat(bootloader, prog):
+    """Verify the bootloader machine matches that of the user program"""
+    bldr_mach = get_machine(bootloader)
+    prog_mach = get_machine(prog)
+    if bldr_mach != prog_mach:
+        raise FormatMismatchError("Bootloader machine ({}) doesn't match "
+                "program machine ({})".format(bldr_mach, prog_mach))
+
+
 def _copy_to_tempfile(srcpath, **kwargs):
     fdst = NamedTemporaryFile(**kwargs)
     with open(srcpath, 'rb') as fsrc:
@@ -80,6 +90,8 @@ def generate(prog, output, libs=None, bootloader=None, strip=False):
     """
     if not bootloader:
         bootloader = _locate_bootloader()
+    _check_bootloader_compat(bootloader, prog)
+
 
     tmpdir = mkdtemp(prefix='staticx-archive-')
 

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -120,14 +120,27 @@ def strip_elf(path):
 ################################################################################
 # Using pyelftools
 
+class ELFCloser(object):
+    def __init__(self, path, mode):
+        self.f = open(path, mode)
+        self.elf = ELFFile(self.f)
+
+    def __enter__(self):
+        return self.elf
+
+    def __exit__(self, *exc_info):
+        self.f.close()
+
+def _open_elf(path, mode='rb'):
+    return ELFCloser(path, mode)
+
+
 def get_machine(path):
-    with open(path, 'rb') as f:
-        elf = ELFFile(f)
+    with _open_elf(path) as elf:
         return elf['e_machine']
 
 def get_prog_interp(path):
-    with open(path, 'rb') as f:
-        elf = ELFFile(f)
+    with _open_elf(path) as elf:
         for seg in elf.iter_segments():
             # Amazingly, this is slightly faster than
             # if isinstance(seg, InterpSegment):

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -4,6 +4,8 @@ import re
 import logging
 import errno
 
+from elftools.elf.elffile import ELFFile
+
 from .errors import *
 
 class ExternTool(object):
@@ -129,3 +131,9 @@ def patch_elf(path, interpreter=None, rpath=None, force_rpath=False):
 
 def strip_elf(path):
     tool_strip.run(path)
+
+
+def get_machine(path):
+    with open(path, 'rb') as f:
+        elf = ELFFile(f)
+        return elf['e_machine']

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -5,6 +5,7 @@ import logging
 import errno
 
 from elftools.elf.elffile import ELFFile
+from elftools.common.exceptions import ELFError
 
 from .errors import *
 
@@ -132,7 +133,10 @@ class ELFCloser(object):
         self.f.close()
 
 def _open_elf(path, mode='rb'):
-    return ELFCloser(path, mode)
+    try:
+        return ELFCloser(path, mode)
+    except ELFError as e:
+        raise InvalidInputError("Invalid ELF image: {}".format(e))
 
 
 def get_machine(path):

--- a/staticx/errors.py
+++ b/staticx/errors.py
@@ -25,6 +25,8 @@ class InvalidInputError(Error):
     """Input provided by the user is invalid"""
     pass
 
+class FormatMismatchError(Error):
+    pass
 
 
 class ArchiveError(Error):


### PR DESCRIPTION
This is a partial fix for #55, ensuring that users don't attempt to use staticx to bundle a 32-bit (compat) binary.

It introduces a dependency on `pyelftools`.