### PR TITLE
Drop support for EOL Python 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 matrix:
   include:
     - python: "2.7"
-    - python: "3.2"
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ The wheels are built on Travis CI and include a bootloader built with
 musl-libc.
 
 You can install using Pip.
-StaticX is compatible with Python 2 (`pip`) or Python 3 (`pip3`):
+StaticX is compatible with Python 2.7 (`pip`) or Python 3.4+ (`pip3`):
 ```
 sudo pip3 install staticx
 ```
 
-*Note:* Python < 3.3 requires the
+*Note:* Python 2.7 requires the
 [`backports.lzma`](https://pypi.python.org/pypi/backports.lzma) package to be
 installed. (See [#45][#45] for details.)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 patchelf-wrapper
-pyinstaller; (python_version == '2.7') or (python_version >= '3.3' and python_version <= '3.5')
+pyinstaller; (python_version <= '3.5')
 scuba
 wheel
-backports.lzma; (python_version < '3.3')
+backports.lzma; (python_version == '2.7')
 pyelftools

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     name = 'staticx',
     version = get_version(),
     description = 'Build static self-extracting app from dynamic executable',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers = [
         'Development Status :: 3 - Alpha',
         'Environment :: Console',
@@ -57,6 +58,13 @@ setup(
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Build Tools',
     ],
     license = 'GPL v2 with special exception allowing StaticX to build and'

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -3,11 +3,11 @@ import logging
 from os.path import basename, islink
 
 try:
-    # Python >= 3.3
+    # Python 3
     import lzma
     lzma.open       # pyliblzma doesn't have lzma.open()
 except (ImportError, AttributeError):
-    # Python < 3.3
+    # Python 2.7
     from backports import lzma
 
 from .bcjfilter import get_bcj_filter_arch


### PR DESCRIPTION
Fixes https://github.com/JonathonReinhart/staticx/issues/64.

Python 3.2 and 3.3 are EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used. Here's the downloads for staticx from PyPI for last month:

| category | percent | downloads |
|----------|--------:|----------:|
| null     |  36.45% |        39 |
| 2.7      |  22.43% |        24 |
| 3.7      |  21.50% |        23 |
| 3.6      |  11.21% |        12 |
| 3.5      |   4.67% |         5 |
| 3.4      |   3.74% |         4 |
| Total    |         |       107 |

And they both break the build. Here's latest master: https://travis-ci.org/hugovk/staticx/builds/445176417
