### PR TITLE
Add support for Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,17 @@ matrix:
     - python: "2.7"
     - python: "3.4"
     - python: "3.5"
+    - python: "3.6"
+    # Enable 3.7 without globally enabling dist: xenial for other build jobs
+    - python: "3.7"
+      dist: xenial
 
     # Test using glibc
     - python: "3.5"
       env: CC=
 
     - python: "3.5-dev" # 3.5 development branch
-    - python: "nightly" # currently points to 3.6-dev
+    - python: "nightly" # currently points to 3.7-alpha
   allow_failures:
     - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,11 @@ addons:
 install:
   # Unset CC before installing Python packages - see #44
   - env -u CC   pip install -r requirements.txt
+  - |
+    if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+      sudo apt-get update
+      sudo apt-get install scons
+    fi
 
 before_script:
   - docker pull $TEST_DOCKER_IMAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # Unset CC before installing Python packages - see #44
   - env -u CC   pip install -r requirements.txt
   - |
-    if [ "$TRAVIS_PYTHON_VERSION" == "3.7" ]; then
+    if [ "$TRAVIS_PYTHON_VERSION" != "3.4" ]; then
       sudo apt-get update
       sudo apt-get install scons
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: required
 serivces:
   - docker
@@ -13,11 +13,10 @@ matrix:
   include:
     - python: "2.7"
     - python: "3.4"
+      dist: trusty
     - python: "3.5"
     - python: "3.6"
-    # Enable 3.7 without globally enabling dist: xenial for other build jobs
     - python: "3.7"
-      dist: xenial
 
     # Test using glibc
     - python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Build Tools',


### PR DESCRIPTION
Python 3.7 needs Xenial (and sudo), see https://github.com/travis-ci/travis-ci/issues/9815.

`scons` needed adding separately for 3.7, this is what happens without it: https://travis-ci.org/hugovk/staticx/builds/445535772
