### PR TITLE
Properly handle RPATH $ORIGIN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,17 +53,9 @@ script:
   - pip install dist/staticx-*-py2.py3-none-any.whl
   - staticx --version
 
-  # Run test (compressed) against system executable
-  - test/date.sh
-
-  # Run test (uncompressed) against system executable
-  - STATICX_FLAGS='--no-compress' test/date.sh
-
-  # Run PyInstaller test
-  - test/pyinstall/run_test.sh
-
-  # Run PyInstaller test, stripping
-  - STATICX_FLAGS='--strip' test/pyinstall/run_test.sh
+  - test/run_all.sh
+  - STATICX_FLAGS='--no-compress' test/run_all.sh
+  - STATICX_FLAGS='--strip' test/run_all.sh
 
 
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scuba
 wheel
 backports.lzma; (python_version == '2.7')
 pyelftools
+cffi        # Used for test/pyinstall-cffi/

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -85,7 +85,7 @@ class PyInstallHook(object):
         make_executable(lib)
 
         # Add any missing libraries to our archive
-        for deppath in get_shobj_deps(lib):
+        for deppath in get_shobj_deps(lib, libpath=[self.tmpdir]):
             dep = os.path.basename(deppath)
 
             if dep in self.sx_ar.libraries:

--- a/test/pyinstall-cffi/.gitignore
+++ b/test/pyinstall-cffi/.gitignore
@@ -1,0 +1,3 @@
+*.spec
+build/
+dist/

--- a/test/pyinstall-cffi/app.py
+++ b/test/pyinstall-cffi/app.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+from cffi import FFI
+import os
+import sys
+
+def main():
+    ffi = FFI()
+    ffi.cdef("""
+      int printf(const char *, ...);
+    """)
+
+    if False:
+        # use a C compiler: verify the decl above is right
+        libc = ffi.verify()
+
+    libc = ffi.dlopen(None)
+
+    libc.printf(b"Hello, %s!\n",
+            ffi.new("char[]", b"world"),
+            )
+
+if __name__ == '__main__':
+    print("PID:", os.getpid())
+    print("MEIPASS:", getattr(sys, '_MEIPASS', '<not set>'))
+
+    main()

--- a/test/pyinstall-cffi/run_test.sh
+++ b/test/pyinstall-cffi/run_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+outfile=./dist/app.staticx
+
+# Only run if PyInstaller is installed
+# By gracefully failing here, we can control which versions of Python this test
+# runs under in requirements.txt
+pyinstaller --version 2>/dev/null || { echo "PyInstaller not installed"; exit 0; }
+
+
+echo -e "\n\nTest StaticX against PyInstalled application"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Run the application normally
+echo -e "\nPython app run normally:"
+python app.py
+
+# Build a PyInstaller "onefile" application
+echo -e "\nBuilding PyInstaller 'onfile' application:"
+pyinstaller -F app.py
+
+# Run the PyInstalled application
+echo -e "\nPyInstalled application run:"
+./dist/app
+
+# Make a staticx executable from it
+echo -e "\nMaking staticx executable (\$STATICX_FLAGS=$STATICX_FLAGS):"
+staticx $STATICX_FLAGS ./dist/app $outfile
+
+# Run that executable
+echo -e "\nRunning staticx executable"
+$outfile
+
+# Run it under an old distro
+if [ -n "$TEST_DOCKER_IMAGE" ]; then
+    echo -e "\nRunning staticx executable under $TEST_DOCKER_IMAGE"
+    scuba --image $TEST_DOCKER_IMAGE $outfile
+fi

--- a/test/rpath-origin/.gitignore
+++ b/test/rpath-origin/.gitignore
@@ -1,0 +1,2 @@
+build/
+dist/

--- a/test/rpath-origin/SConscript
+++ b/test/rpath-origin/SConscript
@@ -1,0 +1,24 @@
+Import('env')
+
+lib = env.SharedLibrary(
+    target = 'bar',
+    source = ['libbar.c'],
+    RPATH = env['LIB_RPATH'],
+)
+env.Install('$LIB_DIR', lib)
+
+lib = env.SharedLibrary(
+    target = 'foo',
+    source = ['libfoo.c'],
+    LIBS = ['bar'],
+    RPATH = env['LIB_RPATH'],
+)
+env.Install('$LIB_DIR', lib)
+
+app = env.Program(
+    target = 'app',
+    source = ['app.c'],
+    LIBS = ['foo'],
+    RPATH = env['PROG_RPATH'],
+)
+env.Install('$BIN_DIR', app)

--- a/test/rpath-origin/SConstruct
+++ b/test/rpath-origin/SConstruct
@@ -1,0 +1,25 @@
+env = Environment(
+    BUILD_DIR = '#build',
+    DIST_DIR = '#dist',
+    LIB_DIR = '$DIST_DIR/lib',
+    BIN_DIR = '$DIST_DIR/bin',
+
+    # https://github.com/SCons/scons/wiki/UsingOrigin
+    LINKFLAGS = ['-z', 'origin'],
+
+    # Programs look for shared libs in ../lib
+    PROG_RPATH = Literal('\\$$ORIGIN/../lib'),
+
+    # Libraries look for shared libs in .
+    LIB_RPATH = Literal('\\$$ORIGIN'),
+
+    CCFLAGS = ['-Wall', '-Werror'],
+    LIBPATH = ['$LIB_DIR'],
+)
+
+env.SConscript(
+    'SConscript',
+    variant_dir = '$BUILD_DIR',
+    duplicate = False,
+    exports = dict(env = env),
+)

--- a/test/rpath-origin/app.c
+++ b/test/rpath-origin/app.c
@@ -4,5 +4,6 @@
 int main(void)
 {
     foo_nop();
+    printf("Success\n");
     return 0;
 }

--- a/test/rpath-origin/app.c
+++ b/test/rpath-origin/app.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include "libfoo.h"
+
+int main(void)
+{
+    foo_nop();
+    return 0;
+}

--- a/test/rpath-origin/libbar.c
+++ b/test/rpath-origin/libbar.c
@@ -1,0 +1,5 @@
+#include "libbar.h"
+
+void bar_nop(void)
+{
+}

--- a/test/rpath-origin/libbar.h
+++ b/test/rpath-origin/libbar.h
@@ -1,0 +1,6 @@
+#ifndef LIBBAR_DOT_H
+#define LIBBAR_DOT_H
+
+void bar_nop(void);
+
+#endif /* LIBBAR_DOT_H */

--- a/test/rpath-origin/libfoo.c
+++ b/test/rpath-origin/libfoo.c
@@ -1,0 +1,7 @@
+#include "libfoo.h"
+#include "libbar.h"
+
+void foo_nop(void)
+{
+    bar_nop();
+}

--- a/test/rpath-origin/libfoo.h
+++ b/test/rpath-origin/libfoo.h
@@ -1,0 +1,6 @@
+#ifndef LIBFOO_DOT_H
+#define LIBFOO_DOT_H
+
+void foo_nop(void);
+
+#endif /* LIBFOO_DOT_H */

--- a/test/rpath-origin/run_test.sh
+++ b/test/rpath-origin/run_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo -e "\n\nTest StaticX against application using RPATH \$ORIGIN"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+app="dist/bin/app"
+outfile="dist/app.staticx"
+
+# Build the application
+scons --quiet
+
+# Run the application normally
+echo -e "\nApp run normally:"
+$app
+
+# Make a staticx executable from it
+echo -e "\nMaking staticx executable (\$STATICX_FLAGS=$STATICX_FLAGS):"
+staticx $STATICX_FLAGS $app $outfile
+
+# Run that executable
+echo -e "\nRunning staticx executable"
+$outfile

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+# Run test against system executable
+./date.sh
+
+# Run test against app built with PyInstaller
+pyinstall/run_test.sh
+
+# Run test against app built with PyInstaller and uses CFFI
+pyinstall-cffi/run_test.sh


### PR DESCRIPTION
This makes a number of fixes which all revolve around using `ldd` to discover dependencies:
- Run `ldd` on executables in their original locations, rather than after they're copied temp directory. This is important if they use `RPATH` which includes `$ORIGIN`
- PyInstaller:
  - Extract all binaries before scanning for dependencies. This is important if there are dependencies present in the PyInstaller archive
  - Set `LD_LIBRARY_PATH` to the temporary directory where we extract files from the PyInstaller archive

Fixes #61 

