### PR TITLE
Set STATICX_* environment variables to communicate runtime info to child process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- Set `STATICX_BUNDLE_DIR` and `STATICX_PROG_PATH` in child process ([#81])
+
+
 ## [0.7.0] - 2019-03-10
 ### Changed
 - Refactored and trimmed libtar ([#74])
@@ -104,3 +109,4 @@ Initial release
 [#74]: https://github.com/JonathonReinhart/staticx/pull/74
 [#75]: https://github.com/JonathonReinhart/staticx/pull/75
 [#77]: https://github.com/JonathonReinhart/staticx/pull/77
+[#81]: https://github.com/JonathonReinhart/staticx/pull/81

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Including additional library files with the package (any number can be specified
 staticx -l /path/to/fancy/library /path/to/exe /path/to/output
 ```
 
+## Run-time Information
+StaticX sets the following environment variables for the wrapped user program:
+- `STATICX_BUNDLE_DIR`: The absolute path of the "bundle" directory, the
+  temporary dir where the archive has been extracted.
+- `STATICX_PROG_PATH`: The absolute path of the program being executed.
+
 
 ## License
 This software is released under the GPLv2, with an exception allowing the

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -231,6 +231,17 @@ restore_sig_handler(int signum)
         error(2, errno, "Error restoring handler for signal %d", signum);
 }
 
+static void
+setup_environment(void)
+{
+    /**
+     * Set STATICX_BUNDLE_DIR to the absolute path of the "bundle" directory,
+     * the temporary dir where the archive has been extracted.
+     */
+    if (setenv("STATICX_BUNDLE_DIR", m_bundle_dir, 1) != 0)
+        error(2, errno, "Error setting STATICX_BUNDLE_DIR=%s", m_bundle_dir);
+}
+
 /**
  * Run the user application in a child process.
  *
@@ -307,6 +318,9 @@ main(int argc, char **argv)
 
     /* Patch the user application ELF to run in the temp dir */
     patch_app(prog_path);
+
+    /* Add STATICX_* variables to the environment for the child */
+    setup_environment();
 
     /* Run the user application */
     int wstatus = run_app(argc, argv, prog_path);

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -240,6 +240,21 @@ setup_environment(void)
      */
     if (setenv("STATICX_BUNDLE_DIR", m_bundle_dir, 1) != 0)
         error(2, errno, "Error setting STATICX_BUNDLE_DIR=%s", m_bundle_dir);
+
+
+    /**
+     * Set STATICX_PROG_PATH to the absolute path of the program being
+     * executed. This is necessary because the user would see /proc/self/exe
+     * as pointing to the extracted binary in the bundle directory.
+     */
+    {
+        char *my_path = realpath("/proc/self/exe", NULL);
+        if (!my_path)
+            error(2, errno, "Failed to read /proc/self/exe");
+        if (setenv("STATICX_PROG_PATH", my_path, 1))
+            error(2, errno, "Error setting STATICX_PROG_PATH=%s", my_path);
+        free(my_path);  /* setenv() copied the string */
+    }
 }
 
 /**

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -18,8 +18,8 @@
 #include "elfutil.h"
 
 
-/* Our "home" directory, where the archive is extracted */
-static const char *m_homedir;
+/* The "bundle" directory, where the archive is extracted */
+static const char *m_bundle_dir;
 
 static char *
 path_join(const char *p1, const char *p2)
@@ -159,8 +159,8 @@ patch_prog_paths(const char *prog_path, const char *new_interp, const char *new_
 static void
 patch_app(const char *prog_path)
 {
-    char *interp_path = path_join(m_homedir, INTERP_FILENAME);
-    const char *new_rpath = m_homedir;
+    char *interp_path = path_join(m_bundle_dir, INTERP_FILENAME);
+    const char *new_rpath = m_bundle_dir;
 
     patch_prog_paths(prog_path, interp_path, new_rpath);
 
@@ -296,14 +296,14 @@ main(int argc, char **argv)
     xz_crc32_init();
 
     /* Create temporary directory where archive will be extracted */
-    m_homedir = create_tmpdir();
-    debug_printf("Home dir: %s\n", m_homedir);
+    m_bundle_dir = create_tmpdir();
+    debug_printf("Temporary bundle dir: %s\n", m_bundle_dir);
 
     /* Extract the archive embedded in this program */
-    extract_archive(m_homedir);
+    extract_archive(m_bundle_dir);
 
     /* Get path to user application inside temp dir */
-    char *prog_path = path_join(m_homedir, PROG_FILENAME);
+    char *prog_path = path_join(m_bundle_dir, PROG_FILENAME);
 
     /* Patch the user application ELF to run in the temp dir */
     patch_app(prog_path);
@@ -315,11 +315,11 @@ main(int argc, char **argv)
     prog_path = NULL;
 
     /* Cleanup */
-    debug_printf("Removing temp dir %s\n", m_homedir);
-    if (remove_tree(m_homedir) < 0) {
-        fprintf(stderr, "staticx: Failed to cleanup %s: %m\n", m_homedir);
+    debug_printf("Removing temporary bundle dir %s\n", m_bundle_dir);
+    if (remove_tree(m_bundle_dir) < 0) {
+        fprintf(stderr, "staticx: Failed to cleanup %s: %m\n", m_bundle_dir);
     }
-    m_homedir = NULL;
+    m_bundle_dir = NULL;
 
     /* Did child exit normally? */
     if (WIFEXITED(wstatus)) {

--- a/bootloader/util.c
+++ b/bootloader/util.c
@@ -7,61 +7,6 @@
 #include <sys/stat.h>
 #include "util.h"
 
-#define MAX_READLINK_ATTEMPT    10
-
-char *
-readlinka(const char *path)
-{
-    char *buf = NULL;
-    struct stat st;
-    size_t bufsz;
-    int i;
-
-    errno = 0;
-
-    for (i = 0; i < MAX_READLINK_ATTEMPT; i++) {
-        /* Determine size of buf contents */
-        if (lstat(path, &st) < 0) {
-            goto fail;
-        }
-
-        /* Allocate buffer */
-        bufsz = st.st_size + 1;
-        buf = malloc(bufsz);
-        if (buf == NULL) {
-            errno = ENOMEM;
-            goto fail;
-        }
-
-        /* Read link into buffer */
-        ssize_t r = readlink(path, buf, bufsz);
-        if (r < 0) {
-            goto fail;
-        }
-
-        /* Check to see if symlink increased in size between
-         * lstat() and readlink() */
-        if (r > st.st_size) {
-            free(buf);
-            buf = NULL;
-            continue;   /* retry */
-        }
-
-        /* NUL terminate and return */
-        buf[r] = '\0';
-        return buf;
-    }
-
-    errno = EAGAIN;
-
-fail:
-    if (buf) {
-        free(buf);
-        buf = NULL;
-    }
-    return NULL;
-}
-
 
 static int
 remove_tree_fn(const char *fpath, const struct stat *sb,

--- a/bootloader/util.h
+++ b/bootloader/util.h
@@ -1,8 +1,6 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-char *readlinka(const char *path);
-
 int remove_tree(const char *pathname);
 
 #endif /* UTIL_H */

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -5,6 +5,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Run test against system executable
 ./date.sh
 
+# Test environment variables
+./staticx-env-vars.sh
+
 # Run test against app built with PyInstaller
 pyinstall/run_test.sh
 

--- a/test/staticx-env-vars.sh
+++ b/test/staticx-env-vars.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+echo -e "\n\nTest StaticX sets STATICX_* vars"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+app="$(which sh)"
+outfile="./sh.staticx"
+
+# Make a staticx executable from bash so we can test STATICX_ env vars
+echo -e "\nMaking staticx executable (\$STATICX_FLAGS=$STATICX_FLAGS):"
+staticx $STATICX_FLAGS $app $outfile
+
+
+# Verify STATICX_BUNDLE_DIR is set to "/tmp/staticx-*"
+test_bundle_dir=$($outfile -c 'echo $STATICX_BUNDLE_DIR')
+echo "STATICX_BUNDLE_DIR: $test_bundle_dir"
+if [[ "$test_bundle_dir" != "/tmp/staticx-"* ]]; then
+    echo "STATICX_BUNDLE_DIR looks wrong: \"$test_bundle_dir\""
+    exit 1
+fi
+
+
+# Verify STATICX_PROG_PATH is set to our application
+test_prog_path=$($outfile -c 'echo $STATICX_PROG_PATH')
+real_outfile="$(realpath $outfile)"
+echo "STATICX_PROG_PATH: $test_prog_path"
+if [[ "$test_prog_path" != "$real_outfile" ]]; then
+    echo "STATICX_PROG_PATH incorrect: \"$test_prog_path\" != \"$real_outfile\""
+    exit 1
+fi


### PR DESCRIPTION
This defines two environment variables which are set by the staticx bootloader to communicate runtime information to the wrapped child process:
- `STATICX_BUNDLE_DIR`: The absolute path of the "bundle" directory, the
  temporary dir where the archive has been extracted. This closes #5.
- `STATICX_PROG_PATH`: The absolute path of the program being executed. This closes #80.

