### PR TITLE
PyInstaller: Ignore static executables and other oddities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Set `STATICX_BUNDLE_DIR` and `STATICX_PROG_PATH` in child process ([#81])
 - Add `--debug` flag to bundle debug bootloader ([#87])
 
+### Changed
+- Changed pyinstaller hook to ignore static executables ([#83])
+
 ### Fixed
 - Always generate tar archive in GNU format. Python 3.8 changed the default to
   PAX which is not supported by our libtar. ([#85])
@@ -115,6 +118,7 @@ Initial release
 [#75]: https://github.com/JonathonReinhart/staticx/pull/75
 [#77]: https://github.com/JonathonReinhart/staticx/pull/77
 [#81]: https://github.com/JonathonReinhart/staticx/pull/81
+[#83]: https://github.com/JonathonReinhart/staticx/pull/83
 [#85]: https://github.com/JonathonReinhart/staticx/pull/85
 [#87]: https://github.com/JonathonReinhart/staticx/pull/87
 [#89]: https://github.com/JonathonReinhart/staticx/pull/89

--- a/test/pyinstall-aux-static-exec/.gitignore
+++ b/test/pyinstall-aux-static-exec/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+aux-static

--- a/test/pyinstall-aux-static-exec/.gitignore
+++ b/test/pyinstall-aux-static-exec/.gitignore
@@ -1,4 +1,6 @@
 build/
 dist/
-aux-static
-aux-dynamic
+aux-glibc-dynamic
+aux-glibc-static
+aux-musl-dynamic
+aux-musl-static

--- a/test/pyinstall-aux-static-exec/.gitignore
+++ b/test/pyinstall-aux-static-exec/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
 aux-static
+aux-dynamic

--- a/test/pyinstall-aux-static-exec/app.py
+++ b/test/pyinstall-aux-static-exec/app.py
@@ -1,0 +1,16 @@
+from __future__ import print_function
+import os
+import sys
+import subprocess
+
+def get_resource_dir():
+    default = os.path.dirname(os.path.abspath(__file__))
+    return getattr(sys, '_MEIPASS', default)
+
+
+def get_resource(name):
+    return os.path.join(get_resource_dir(), name)
+
+
+auxapp = get_resource('aux-static')
+subprocess.check_call([auxapp])

--- a/test/pyinstall-aux-static-exec/app.py
+++ b/test/pyinstall-aux-static-exec/app.py
@@ -1,7 +1,10 @@
 from __future__ import print_function
+import argparse
 import os
 import sys
 import subprocess
+
+from auxlist import aux_apps
 
 def get_resource_dir():
     default = os.path.dirname(os.path.abspath(__file__))
@@ -12,6 +15,26 @@ def get_resource(name):
     return os.path.join(get_resource_dir(), name)
 
 
-for name in ('aux-dynamic', 'aux-static'):
-    auxapp = get_resource(name)
-    subprocess.check_call([auxapp])
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--skip', action='append', default=[],
+            help="aux apps to skip")
+    return ap.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Run whichever binaries were compiled
+    for name in aux_apps:
+        if name in args.skip:
+            continue
+
+        auxapp = get_resource(name)
+
+        # Try to run the file if it was included
+        if os.path.isfile(auxapp):
+            subprocess.check_call([auxapp])
+
+if __name__ == '__main__':
+    main()

--- a/test/pyinstall-aux-static-exec/app.py
+++ b/test/pyinstall-aux-static-exec/app.py
@@ -12,5 +12,6 @@ def get_resource(name):
     return os.path.join(get_resource_dir(), name)
 
 
-auxapp = get_resource('aux-static')
-subprocess.check_call([auxapp])
+for name in ('aux-dynamic', 'aux-static'):
+    auxapp = get_resource(name)
+    subprocess.check_call([auxapp])

--- a/test/pyinstall-aux-static-exec/app.spec
+++ b/test/pyinstall-aux-static-exec/app.spec
@@ -1,5 +1,6 @@
 a = Analysis(['app.py'],
              binaries=[
+                 ('aux-dynamic', '.'),
                  ('aux-static', '.'),
              ],
              datas=[],

--- a/test/pyinstall-aux-static-exec/app.spec
+++ b/test/pyinstall-aux-static-exec/app.spec
@@ -1,8 +1,17 @@
+import os
+import sys
+
+# Add the diretory of the .spec file to the python path
+specdir = os.path.abspath(SPECPATH)
+sys.path.append(specdir)
+
+from auxlist import aux_apps
+
+# Add whichever binaries were compiled
+binaries = [(b, '.') for b in aux_apps if os.path.isfile(b)]
+
 a = Analysis(['app.py'],
-             binaries=[
-                 ('aux-dynamic', '.'),
-                 ('aux-static', '.'),
-             ],
+             binaries=binaries,
              datas=[],
              excludes=[],
              noarchive=False)

--- a/test/pyinstall-aux-static-exec/app.spec
+++ b/test/pyinstall-aux-static-exec/app.spec
@@ -1,0 +1,23 @@
+a = Analysis(['app.py'],
+             binaries=[
+                 ('aux-static', '.'),
+             ],
+             datas=[],
+             excludes=[],
+             noarchive=False)
+
+pyz = PYZ(a.pure, a.zipped_data)
+
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='app',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          runtime_tmpdir=None,
+          console=True )

--- a/test/pyinstall-aux-static-exec/aux.c
+++ b/test/pyinstall-aux-static-exec/aux.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
 
+#ifndef STATIC
+# define STATIC 0
+#endif
+
 int main(int argc, char **argv)
 {
-    printf("aux: Hello from our auxiliary statically-linked app:\n");
-    printf("aux: %s\n", argv[0]);
+    printf("aux: Hello from our %sauxiliary app: %s\n",
+            STATIC ? "statically-linked " : "",
+            argv[0]);
     return 0;
 }

--- a/test/pyinstall-aux-static-exec/aux.c
+++ b/test/pyinstall-aux-static-exec/aux.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    printf("aux: Hello from our auxiliary statically-linked app:\n");
+    printf("aux: %s\n", argv[0]);
+    return 0;
+}

--- a/test/pyinstall-aux-static-exec/auxlist.py
+++ b/test/pyinstall-aux-static-exec/auxlist.py
@@ -1,0 +1,6 @@
+aux_apps = (
+    'aux-glibc-dynamic',
+    'aux-glibc-static',
+    'aux-musl-dynamic',
+    'aux-musl-static',
+)

--- a/test/pyinstall-aux-static-exec/run_test.sh
+++ b/test/pyinstall-aux-static-exec/run_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+outfile=./dist/app.staticx
+
+# Only run if PyInstaller is installed
+# By gracefully failing here, we can control which versions of Python this test
+# runs under in requirements.txt
+pyinstaller --version 2>/dev/null || { echo "PyInstaller not installed"; exit 0; }
+
+
+echo -e "\n\nTest StaticX against PyInstalled application which includes a statically-linked aux app"
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+
+# Build our auxiliary app
+gcc -Wall -Werror -Os -static -s -o aux-static aux.c
+
+# Run the application normally
+echo -e "\nPython app run normally:"
+python app.py
+
+# Build a PyInstaller "onefile" application
+echo -e "\nBuilding PyInstaller 'one-file' application:"
+pyinstaller -F app.spec
+
+# Run the PyInstalled application
+echo -e "\nPyInstalled application run:"
+./dist/app
+
+# Make a staticx executable from it
+echo -e "\nMaking staticx executable (\$STATICX_FLAGS=$STATICX_FLAGS):"
+staticx $STATICX_FLAGS ./dist/app $outfile
+
+# Run that executable
+echo -e "\nRunning staticx executable"
+$outfile
+
+# Run it under an old distro
+if [ -n "$TEST_DOCKER_IMAGE" ]; then
+    echo -e "\nRunning staticx executable under $TEST_DOCKER_IMAGE"
+    scuba --image $TEST_DOCKER_IMAGE $outfile
+fi

--- a/test/pyinstall-aux-static-exec/run_test.sh
+++ b/test/pyinstall-aux-static-exec/run_test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-: ${CC:=gcc}
 CCFLAGS="-Wall -Werror -Os -s"
+CCFLAGS_STATIC="$CCFLAGS -static -DSTATIC=1"
 
 outfile=./dist/app.staticx
 
@@ -18,9 +18,16 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 
 # Build our auxiliary app
-rm -f aux-dynamic aux-static
-$CC $CCFLAGS -o aux-dynamic aux.c
-$CC $CCFLAGS -static -DSTATIC=1 -o aux-static aux.c
+echo "Building aux app with gcc"
+gcc $CCFLAGS        -o aux-glibc-dynamic aux.c
+gcc $CCFLAGS_STATIC -o aux-glibc-static  aux.c
+
+if [ -x "$(command -v musl-gcc)" ]; then
+    echo "Building aux app with musl-gcc"
+    musl-gcc $CCFLAGS        -o aux-musl-dynamic aux.c
+    musl-gcc $CCFLAGS_STATIC -o aux-musl-static  aux.c
+fi
+
 
 # Run the application normally
 echo -e "\nPython app run normally:"
@@ -45,5 +52,7 @@ $outfile
 # Run it under an old distro
 if [ -n "$TEST_DOCKER_IMAGE" ]; then
     echo -e "\nRunning staticx executable under $TEST_DOCKER_IMAGE"
-    scuba --image $TEST_DOCKER_IMAGE $outfile
+
+    # This environment won't have a dynamic musl-libc
+    scuba --image $TEST_DOCKER_IMAGE $outfile --skip aux-musl-dynamic
 fi

--- a/test/pyinstall-aux-static-exec/run_test.sh
+++ b/test/pyinstall-aux-static-exec/run_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
+
+: ${CC:=gcc}
+CCFLAGS="-Wall -Werror -Os -s"
+
 outfile=./dist/app.staticx
 
 # Only run if PyInstaller is installed
@@ -14,7 +18,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 
 
 # Build our auxiliary app
-gcc -Wall -Werror -Os -static -s -o aux-static aux.c
+rm -f aux-dynamic aux-static
+$CC $CCFLAGS -o aux-dynamic aux.c
+$CC $CCFLAGS -static -DSTATIC=1 -o aux-static aux.c
 
 # Run the application normally
 echo -e "\nPython app run normally:"

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -13,3 +13,6 @@ pyinstall/run_test.sh
 
 # Run test against app built with PyInstaller and uses CFFI
 pyinstall-cffi/run_test.sh
+
+# Run test against app built with PyInstaller and includes a helper app
+pyinstall-aux-static-exec/run_test.sh


### PR DESCRIPTION
This PR updates the PyInstaller hook to ignore static executables or other `BINARY` files that cause `ldd` to choke when looking for dependencies.

This fixes #78.