### PR TITLE
staticx: Force creation of GNU_FORMAT tar files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Set `STATICX_BUNDLE_DIR` and `STATICX_PROG_PATH` in child process ([#81])
 
+### Fixed
+- Always generate tar archive in GNU format. Python 3.8 changed the default to
+  PAX which is not supported by our libtar. ([#85])
 
 ## [0.7.0] - 2019-03-10
 ### Changed
@@ -110,3 +113,4 @@ Initial release
 [#75]: https://github.com/JonathonReinhart/staticx/pull/75
 [#77]: https://github.com/JonathonReinhart/staticx/pull/77
 [#81]: https://github.com/JonathonReinhart/staticx/pull/81
+[#85]: https://github.com/JonathonReinhart/staticx/pull/85

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -60,7 +60,8 @@ class SxArchive(object):
 
             fileobj = self.xzf
 
-        self.tar = tarfile.open(fileobj=fileobj, mode=mode)
+        # Our embedded libtar only supports older GNU format (not new PAX format)
+        self.tar = tarfile.open(fileobj=fileobj, mode=mode, format=tarfile.GNU_FORMAT)
         self._added_libs = []
 
     def __enter__(self):


### PR DESCRIPTION
Python 3.8 changed the default from GNU_FORMAT to PAX_FORMAT which is not supported by our embedded libtar. Force the creation of older GNU_FORMAT tar files.

Fixes #84