### PR TITLE
Add backports.lzma to install_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - TEST_DOCKER_IMAGE=centos:5
   matrix:
-  - CC=musl-gcc     # Default to musl libc
+  - BOOTLOADER_CC=musl-gcc     # Default to musl libc
 matrix:
   include:
     - python: "2.7"
@@ -18,7 +18,7 @@ matrix:
 
     # Test using glibc
     - python: "3.5"
-      env: CC=
+      env: BOOTLOADER_CC=
 
     - python: "nightly" # currently points to 3.7-alpha
       env: STATICX_FLAGS='--debug'
@@ -34,16 +34,12 @@ addons:
       - liblzma-dev
       - scons
 
-install:
-  # Unset CC before installing Python packages - see #44
-  - env -u CC   pip install -r requirements.txt
-
 before_script:
   - docker pull $TEST_DOCKER_IMAGE
 
 script:
   # Build and install a wheel
-  - python setup.py bdist_wheel
+  - CC=${BOOTLOADER_CC} python setup.py bdist_wheel
   - pip install dist/staticx-*-py2.py3-none-any.whl
   - staticx --version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Always generate tar archive in GNU format. Python 3.8 changed the default to
   PAX which is not supported by our libtar. ([#85])
+- Add backports.lzma to setup.py for Python 2, removing manual requirement ([#89])
 
 ## [0.7.0] - 2019-03-10
 ### Changed
@@ -116,3 +117,4 @@ Initial release
 [#81]: https://github.com/JonathonReinhart/staticx/pull/81
 [#85]: https://github.com/JonathonReinhart/staticx/pull/85
 [#87]: https://github.com/JonathonReinhart/staticx/pull/87
+[#89]: https://github.com/JonathonReinhart/staticx/pull/89

--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@ StaticX is compatible with Python 2.7 (`pip`) or Python 3.4+ (`pip3`):
 sudo pip3 install staticx
 ```
 
-*Note:* Python 2.7 requires the
-[`backports.lzma`](https://pypi.python.org/pypi/backports.lzma) package to be
-installed. (See [#45][#45] for details.)
-
 ### From source
 
 If you have musl libc installed, you can use it to build the staticx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
+# These requirements are in addition to install_requires from setup.py
+# and are only used for development and testing.
 patchelf-wrapper
 pyinstaller; (python_version <= '3.7')
 scuba
 wheel
-backports.lzma; (python_version == '2.7')
-pyelftools
 cffi        # Used for test/pyinstall-cffi/

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     },
     install_requires = [
         'pyelftools',
+        'backports.lzma;python_version<"3.3"',
     ],
 
     # http://stackoverflow.com/questions/17806485


### PR DESCRIPTION
Previously, we did not include the `backports.lzma` package in the `install_requires` list in `setup.py` because `wheel` didn't support PEP508 environment markers, which we need to indicate that it should only be included for Python < 3.3.

pypa/wheel#172 and pypa/wheel#181 have both been closed, indicating that the issue is fixed in setuptools version 36.2.0. So we can now use the environment markers, and hope users are using a new enough version of setuptools. If not, then they'll simply end up with `backports.lzma` unnecessarily installed.

Fixes #45.

Also re-fixes #44 by reverting 6213896f7345bf7d3c7d0fd08ef437c0b4dbc8af.