### PR TITLE
ci: Fix the CC issue once again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - TEST_DOCKER_IMAGE=centos:5
   matrix:
-  - BOOTLOADER_CC=musl-gcc     # Default to musl libc
+  - CC=musl-gcc     # Default to musl libc
 matrix:
   include:
     - python: "2.7"
@@ -18,7 +18,7 @@ matrix:
 
     # Test using glibc
     - python: "3.5"
-      env: BOOTLOADER_CC=
+      env: CC=
 
     - python: "nightly" # currently points to 3.7-alpha
       env: STATICX_FLAGS='--debug'
@@ -34,15 +34,25 @@ addons:
       - liblzma-dev
       - scons
 
+install:
+  # Unset CC before installing Python packages so we don't interfere
+  - env -u CC   pip install -r requirements.txt
+
 before_script:
   - docker pull $TEST_DOCKER_IMAGE
 
 script:
-  # Build and install a wheel
-  - CC=${BOOTLOADER_CC} python setup.py bdist_wheel
-  - pip install dist/staticx-*-py2.py3-none-any.whl
+  # Build a wheel using our global CC env var
+  - python setup.py bdist_wheel
+
+  # Install staticx from the wheel
+  # Unset CC so we don't interfere with dependencies being installed
+  - env -u CC  pip install dist/staticx-*-py2.py3-none-any.whl
+
+  # Quick sanity check
   - staticx --version
 
+  # Run a variety of tests
   - test/run_all.sh
   - STATICX_FLAGS='--no-compress' test/run_all.sh
   - STATICX_FLAGS='--strip' test/run_all.sh
@@ -59,7 +69,6 @@ deploy:
     password:
       secure: "3XzW3vsUh4UmHgoJasxnXAv9+ZBnOn5pSO9avNyUCAn1XqzjZoJ3dztzyJ8Do/GNcsbEAdTdiwfCSNBj0Z+ASeGCkxqkXD3bqSCHD1mJVe5RcpNHJ2ZfME6KuE7wl0mMSoz8NAC2xvBls/AYUFT5y1aLmzwSurCo+e7InY9np/1iBrdc0BiKJkK+bZ02r8lJB9OeAG3rsd3cQugX4h9Znbq10L18U/LY1yFAGZEZS3c38yjDkUSvujXQxssJF0XBbKncalm2YXnvbH3yNeE6L7HMDtMIIyJZgrc5cUxV5Dkxtny8u51ciOYf017yFyo19F48mGy5pTLnPeANG8Ipu+eEUlfZAJAH5VUix5wxKLSwnqqemyvQzj/YKEVmg9JzLZRZ+Meq2YQiESWEJbAxPPr3GzRmRuG9Pa3Uu5KE/h2I9H/oqCJbtdHJQKR92OXDuRIXvqABeUIsZpONBSrFUDj3PJHMnyyD5CGxLCgDww9lmnl8fN49rOSgpzd2JMxkEOXK9+J8GBZWfRoyijQrKC/lfuNFHQIOTk5ZQxiIuvpoGn5N3xvP2C35tGMmPL+fSQV/Jb7SKt2Xdi/fCts6zLEnU431glsgXPS1vzBtdLLj1tVDJPuGQBlcpaMNBf/2JB9NC9bvtuyksdbeSU2KfF2LslNFK+rasQqnO41ce4U="
     distributions: "sdist bdist_wheel"
-    skip_cleanup: true
     on:
       branch: master
       tags: false
@@ -72,7 +81,6 @@ deploy:
     password:
       secure: "FJMDJTi1zHOO33SXhzsF7si7VtTi0LIPaVLRlbhmgaBjPXyLKn6ULYG1kQFn49Svu3J7+5tQOpMfi4xBJbHep1dDQb3lIm2IZI9aZ6wkxI0coH0xFihhO1/VuQodnFjda6N92wWICDpC2iKDKI4fppeJbp6FprCKH9JElFIxdoLRgpxiHOJvHpzk/pQRWQbR/2MU7MhDNvRh19/Uy9DkAUnOJl4csM6h4rAukEB+JwK8zo9g/W/DytpksVaBsgG0gpM31icxwoDpTjzY1aAfN8BxJ9olD09rSpuM/rs+twQPjWHuhGO4jY4ofc4Iwc0y2xqM+5b/s+prNgxBa13naro55euTKlaqoX4nkrCJcGfU6zYuGQ/iqmO7NjtGbiUpE4UCa0B9lm5NXwifM3xBZMvhRajZ/Mpb7MsKmm4avkA0FUHADubdjwLlg6Xkg9hqG+NnVvQEApeuDUkNAV2rpAnUBOjcubIggB+VpVSK8ToUKNGyUtrP2ePJd/HQ3dUzNZgXB2RjgfGFVnXxltVOuC5gqiW4/KYJ8GnSTszTDchzJogCkNUzuarDm+JSAqjzw/6qjEk2kx5BLiPW6jWeSCES+0ZaLwA9jy9MbJDUq4eHFhgrhQCqBQ9oqPQS+Q8GPH8xXS6KN2vFAsB3WSADGwK0zeKJ/yBHtfObVtwBO9M="
     distributions: "sdist bdist_wheel"
-    skip_cleanup: true
     on:
       branch: master
       tags: true


### PR DESCRIPTION
We want to set CC only when building a wheel. This happens in two places:
- When running "python setup.py bdist_wheel" for testing
- When letting Travis build a wheel for pypi deployment

We specifically do *not* want to set CC when running "pip install",
otherwise we'll try to use musl-libc when building other packages'
extensions:
- When running "pip install requirements.txt" for dev/test deps
- When running "pip install *.whl" for testing


History:
- #44 first noticed that setting CC interfered with "pip install"
- 0a2deae6 tried to fix this with BOOTLOADER_CC...
- ...but that led to #48 where the released wheels weren't built with musl
- #49 tried to fix this with "skip_cleanup: true" but that didn't work
- #50 then fixed it by unsetting CC before (manually) running
  "pip install -r requirements.txt"
- #89 moved packages from requirements.txt to only setup.py, which caused
  more packages to be installed automatically by "pip install ...*.whl",
  leading to another place where CC interfered with pip. So that MR
  reverted 6213896f, re-introducing #48.

Ugh. So this effectively re-introduces #50, but does so for *both*
invocations of pip. Hopefully this takes care of the problem for good.

Fixes #48.