### PR TITLE
Use environment-specified temp dir if available

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -207,8 +207,9 @@ create_tmpdir(void)
     const char* tmpdir_env = getenv("TMPDIR");
     size_t tmpdir_size;
     tmpdir_size = snprintf(NULL, 0, "%s/%s", (tmpdir_env!=NULL) ? tmpdir_env : "/tmp", "staticx-XXXXXX");
-    static char *template = malloc(tmpdir_size +1);
-    snprintf(template, tmpdir_size +1, "%s/%s", tmpdir_base, "staticx-XXXXXX");
+    static char *template;
+    template = (char *)malloc(tmpdir_size +1);
+    snprintf(template, tmpdir_size + 1, "%s/%s", (tmpdir_env!=NULL) ? tmpdir_env : "/tmp", "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -205,11 +205,10 @@ static char *
 create_tmpdir(void)
 {
     const char* tmpdir_env = getenv("TMPDIR");
-    const char tmpdir_base[] = (tmpdir_env!=NULL) ? tmpdir_env : "/tmp";
     size_t tmpdir_size;
-    tmpdir_size = snprintf(NULL, "%s/%s", tmpdir_base, "staticx-XXXXXX");
+    tmpdir_size = snprintf(NULL, 0, "%s/%s", (tmpdir_env!=NULL) ? tmpdir_env : "/tmp", "staticx-XXXXXX");
     static char *template = malloc(tmpdir_size +1);
-    snprintf(template, "%s/%s", tmpdir_base, "staticx-XXXXXX");
+    snprintf(template, tmpdir_size +1, "%s/%s", tmpdir_base, "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -204,7 +204,9 @@ patch_app(const char *prog_path)
 static char *
 create_tmpdir(void)
 {
-    static char template[] = "/tmp/staticx-XXXXXX";
+    const char* tmpdir_env = getenv("TMPDIR");
+    const char tmpdir[] = (tmpdir_env!=NULL)? &tmpdir_env : "/tmp"
+    static char template[] = printf("%s/%s", tmpdir, "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -205,7 +205,11 @@ static char *
 create_tmpdir(void)
 {
     const char* tmpdir_env = getenv("TMPDIR");
-    static char template[] = printf("%s/%s", (tmpdir_env!=NULL) ? tmpdir_env : "/tmp", "staticx-XXXXXX");
+    const char tmpdir_base[] = (tmpdir_env!=NULL) ? tmpdir_env : "/tmp";
+    size_t tmpdir_size;
+    tmpdir_size = snprintf(NULL, "%s/%s", tmpdir_base, "staticx-XXXXXX");
+    static char *template = malloc(tmpdir_size +1);
+    snprintf(template, "%s/%s", tmpdir_base, "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -205,8 +205,7 @@ static char *
 create_tmpdir(void)
 {
     const char* tmpdir_env = getenv("TMPDIR");
-    const char tmpdir[] = (tmpdir_env!=NULL)? &tmpdir_env : "/tmp"
-    static char template[] = printf("%s/%s", tmpdir, "staticx-XXXXXX");
+    static char template[] = printf("%s/%s", (tmpdir_env!=NULL) ? &tmpdir_env : "/tmp", "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -205,7 +205,7 @@ static char *
 create_tmpdir(void)
 {
     const char* tmpdir_env = getenv("TMPDIR");
-    static char template[] = printf("%s/%s", (tmpdir_env!=NULL) ? &tmpdir_env : "/tmp", "staticx-XXXXXX");
+    static char template[] = printf("%s/%s", (tmpdir_env!=NULL) ? tmpdir_env : "/tmp", "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");


### PR DESCRIPTION
Running into issues attempting to run a `staticx` compiled binary in an environment where `/tmp` has `noexec` set and I am not allowed to change that setting