### PR TITLE
Handle BOOTLOADER_CC in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 
 script:
   # Build and install a wheel
-  - CC=${BOOTLOADER_CC} python setup.py bdist_wheel
+  - python setup.py bdist_wheel
   - pip install dist/staticx-*-py2.py3-none-any.whl
   - staticx --version
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,18 @@ sudo pip3 install staticx
 ### From source
 
 If you have musl libc installed, you can use it to build the staticx
-bootloader, resulting in smaller, better binaries. Simply set the `CC`
-environment variable to your `musl-gcc` wrapper path:
-```
-sudo CC=/usr/local/musl/bin/musl-gcc pip3 install https://github.com/JonathonReinhart/staticx/archive/master.zip
-```
-### Building from cloned repository
+bootloader, resulting in smaller, better binaries. To do so, set the
+`BOOTLOADER_CC` environment variable to your `musl-gcc` wrapper path
+wehn invoking `pip` or `setup.py`:
 
-- Ensure dependencies are installed as above.
-- Change to the root repository directory
-- Run `scons`
-- Run `python setup.py install`
+```
+sudo BOOTLOADER_CC=/usr/local/musl/bin/musl-gcc pip3 install https://github.com/JonathonReinhart/staticx/archive/master.zip
+```
+
+```
+cd staticx
+sudo BOOTLOADER_CC=/usr/local/musl/bin/musl-gcc pip3 install .
+```
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,11 @@ class build_bootloader(Command):
         pass
 
     def run(self):
-        check_call(['scons'])
+        args = ['scons']
+        cc = os.environ.get('BOOTLOADER_CC')
+        if cc:
+            args.append('CC='+cc)
+        check_call(args)
 
 
 class build_hook(build):


### PR DESCRIPTION
We want to set CC only when building a wheel. This happens in two places:
- When running "python setup.py bdist_wheel" for testing
- When letting Travis build a wheel for pypi deployment

We specifically do *not* want to set CC when running "pip install",
otherwise we'll try to use musl-libc when building other packages'
extensions:
- When running `pip install requirements.txt` for dev/test deps
- When running `pip install *.whl` for testing


History:
- #44 first noticed that setting CC interfered with "pip install"
- 0a2deae6 tried to fix this with `BOOTLOADER_CC`...
  - ...but that led to #48 where the released wheels weren't built with musl because it only handled the test, and not the deploy job
- #49 tried to fix this with "skip_cleanup: true" but that didn't work
- #50 then fixed it by unsetting CC before (manually) running
  "pip install -r requirements.txt"
- #89 moved packages from requirements.txt to only setup.py, which caused
  more packages to be installed automatically by "pip install ...*.whl",
  leading to another place where CC interfered with pip. So that MR
  reverted 6213896f, re-introducing #48.

We avoid the issue by never setting `CC` in `.travis.yml` which proves to be tricky. Instead we use `BOOTLOADER_CC` to communicate the compiler to `setup.py`, which will pass this on to `SConstruct`.

Fixes #48.