### PR TITLE
Respect $TMPDIR

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -24,6 +24,7 @@
 
 /* Keep temporary files */
 #define STATICX_KEEP_TEMPS      "STATICX_KEEP_TEMPS"
+#define TMPDIR                  "TMPDIR"
 
 
 
@@ -204,10 +205,11 @@ patch_app(const char *prog_path)
 static char *
 create_tmpdir(void)
 {
-    static char template[] = "/tmp/staticx-XXXXXX";
+    char *template = path_join(getenv(TMPDIR) ?: "/tmp", "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
         error(2, errno, "Failed to create tempdir");
+    assert(tmpdir == template);
     return tmpdir;
 }
 
@@ -375,6 +377,8 @@ cleanup_bundle_dir(void)
     if (remove_tree(m_bundle_dir) < 0) {
         fprintf(stderr, "staticx: Failed to cleanup %s: %m\n", m_bundle_dir);
     }
+
+    free((void*)m_bundle_dir);
     m_bundle_dir = NULL;
 }
 

--- a/test/staticx-env-vars.sh
+++ b/test/staticx-env-vars.sh
@@ -21,6 +21,15 @@ if [[ "$test_bundle_dir" != "/tmp/staticx-"* ]]; then
     exit 1
 fi
 
+# Verify staticx respects $TMPDIR
+export TMPDIR="/tmp/my/special/tmpdir"
+mkdir -p $TMPDIR
+test_bundle_dir=$($outfile -c 'echo $STATICX_BUNDLE_DIR')
+echo "STATICX_BUNDLE_DIR: $test_bundle_dir"
+if [[ "$test_bundle_dir" != "${TMPDIR}/staticx-"* ]]; then
+    echo "STATICX_BUNDLE_DIR looks wrong: \"$test_bundle_dir\""
+    exit 1
+fi
 
 # Verify STATICX_PROG_PATH is set to our application
 test_prog_path=$($outfile -c 'echo $STATICX_PROG_PATH')


### PR DESCRIPTION
`$TMPDIR` is a *de facto* standard environment variable which specifies an alternative to `/tmp`, respected by many applications, e.g.:
- `bash(1)`
- `busybox(1)`
- `mktemp(1)`
- `tempfile(1)`

This updates the staticx bootloader to also respect `$TMPDIR`.

This was inspired by the request in #97.