### PR TITLE
Annotate error() with format attribute

### DIFF
--- a/bootloader/error.h
+++ b/bootloader/error.h
@@ -1,6 +1,6 @@
 #ifndef ERROR_H
 #define ERROR_H
 
-void error(int status, int errnum, const char *format, ...);
+void error(int status, int errnum, const char *format, ...)  __attribute__ ((format (printf, 3, 4) ));
 
 #endif /* ERROR_H */

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -349,7 +349,7 @@ run_app(int argc, char **argv, char *prog_path)
     while (waitpid(child_pid, &wstatus, 0) < 0) {
         if (errno == EINTR)
             continue;
-        error(2, errno, "Failed to wait for child process %ld", child_pid);
+        error(2, errno, "Failed to wait for child process %d", child_pid);
     }
     child_pid = 0;
 


### PR DESCRIPTION
It's always good to have some compiler-supported checking. This is GCC-specific. I can wrap it into a macro if necessary.