### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 matrix:
   include:
     - python: "2.7"
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Don't hard-code exclusion of `linux-vdso.so.1` ([#102])
 
+### Removed
+- Drop support for Python 3.4 ([#111])
+
 
 ## [0.8.1] - 2019-12-30
 ### Changed
@@ -139,3 +142,4 @@ Initial release
 [#89]: https://github.com/JonathonReinhart/staticx/pull/89
 [#101]: https://github.com/JonathonReinhart/staticx/pull/101
 [#102]: https://github.com/JonathonReinhart/staticx/pull/102
+[#111]: https://github.com/JonathonReinhart/staticx/pull/111

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     name = 'staticx',
     version = get_dynamic_version(),
     description = 'Build static self-extracting app from dynamic executable',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     classifiers = [
         'Development Status :: 3 - Alpha',
         'Environment :: Console',


### PR DESCRIPTION
Python 3.4 is EOL since 2019-03-18 and is no longer supported by PyYAML 5.3.

See #107 