### PR TITLE
Remove support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - BOOTLOADER_CC=musl-gcc     # Default to musl libc
 matrix:
   include:
-    - python: "2.7"
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
@@ -42,7 +41,7 @@ script:
 
   # Build and install a wheel
   - python setup.py bdist_wheel
-  - pip install dist/staticx-*-py2.py3-none-any.whl
+  - pip install dist/staticx-*-py3-none-any.whl
   - staticx --version
 
   # Run unit tests
@@ -72,7 +71,7 @@ deploy:
       branch: master
       tags: false
       repo: JonathonReinhart/staticx
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
+      condition: $TRAVIS_PYTHON_VERSION = "3.6"
 
   # Production PyPI (only on tags)
   - provider: pypi
@@ -85,4 +84,4 @@ deploy:
       branch: master
       tags: true
       repo: JonathonReinhart/staticx
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
+      condition: $TRAVIS_PYTHON_VERSION = "3.6"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The wheels are built on Travis CI and include a bootloader built with
 musl-libc.
 
 You can install using Pip.
-StaticX is compatible with Python 2.7 (`pip`) or Python 3.4+ (`pip3`):
+StaticX is compatible with Python Python 3.5+ (`pip3`):
 ```
 sudo pip3 install staticx
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-# Python 2 and 3 compatible
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # Derived from https://github.com/JonathonReinhart/scuba
-from __future__ import print_function
 from setuptools import setup, Command, find_packages
 from distutils.command.build import build
 import os
@@ -47,7 +46,7 @@ setup(
     name = 'staticx',
     version = get_dynamic_version(),
     description = 'Build static self-extracting app from dynamic executable',
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     long_description = read_project_file('README.md'),
     long_description_content_type = 'text/markdown',
     classifiers = [
@@ -57,10 +56,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -95,7 +91,6 @@ setup(
     },
     install_requires = [
         'pyelftools',
-        'backports.lzma;python_version<"3.3"',
     ],
 
     # http://stackoverflow.com/questions/17806485

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import sys
 import logging

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -1,14 +1,7 @@
 import tarfile
 import logging
+import lzma
 from os.path import basename, islink
-
-try:
-    # Python 3
-    import lzma
-    lzma.open       # pyliblzma doesn't have lzma.open()
-except (ImportError, AttributeError):
-    # Python 2.7
-    from backports import lzma
 
 from .bcjfilter import get_bcj_filter_arch
 from .utils import get_symlink_target, make_mode_executable

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -23,16 +23,6 @@ def move_file(src, dst):
     shutil.move(src, dst)
 
 
-def mkdir_p(path):
-    # TODO Py2.7: Python 3 can simply use
-    # os.makedirs(path, exist_ok=True)
-    try:
-        os.makedirs(path)
-    except OSError as oe:
-        if oe.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
-
 def mkdirs_for(filename):
-    mkdir_p(os.path.dirname(filename))
+    dirname = os.path.dirname(filename)
+    os.makedirs(dirname, exist_ok=True)

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from os.path import abspath, dirname, exists, join, normpath
 import subprocess
 import sys

--- a/test/pyinstall-aux-static-exec/app.py
+++ b/test/pyinstall-aux-static-exec/app.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import os
 import sys

--- a/test/pyinstall-cffi/app.py
+++ b/test/pyinstall-cffi/app.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from cffi import FFI
 import os
 import sys

--- a/test/pyinstall/app.py
+++ b/test/pyinstall/app.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import os
 import sys
 


### PR DESCRIPTION
Python 2.7 is effectively dead as of 2020 Jan 1. This PR removes support for Python 2.7 entirely, and joins the company of other projects that are now Python 3 only.

There is extra code that StaticX has to maintain to keep support for Python 2.7. By dropping this version of Python, StaticX can move forward unencumbered by legacy issues.

Also, it enables support or simplifies implementation of new features (e.g. #114).

Closes #107

*Does anyone have major heartburn with this change?*