### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,23 @@ before_script:
   - docker pull $TEST_DOCKER_IMAGE
 
 script:
+  # https://github.com/travis-ci/travis-ci/issues/1066
+  - set -e
+
   # Build and install a wheel
   - python setup.py bdist_wheel
   - pip install dist/staticx-*-py2.py3-none-any.whl
   - staticx --version
 
+  # Run unit tests
+  - pytest -v
+
+  # Run integration tests
   - test/run_all.sh
   - STATICX_FLAGS='--no-compress' test/run_all.sh
   - STATICX_FLAGS='--strip' test/run_all.sh
+
+  - set +e
 
 
 deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyinstaller; (python_version <= '3.7')
 scuba
 wheel
 cffi        # Used for test/pyinstall-cffi/
+pytest

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# https://docs.pytest.org/en/latest/pythonpath.html#pytest-vs-python-m-pytest
+# "Running pytest with python -m pytest [...] instead of pytest [...] yields
+# nearly equivalent behaviour, except that the former call will add the current
+# directory to sys.path."
+
+exec python3 -m pytest -v "$@"

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -82,6 +82,45 @@ class LddError(ToolError):
         super(LddError, self).__init__('ldd', message)
 
 
+def _parse_ldd_output(output):
+    # Example:
+    #	linux-vdso.so.1 (0x00007ffe53551000)
+    #     or
+    #	linux-vdso.so.1 =>  (0x00007ffe53551000)
+    #	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f42ac010000)
+    #	/lib64/ld-linux-x86-64.so.2 (0x0000557376e75000)
+    pat = re.compile(r'\t([\w./+-]*) (?:=> ([\w./+-]*) )?\((0x[0-9a-fA-F]*)\)')
+
+    for line in output.splitlines():
+        m = pat.match(line)
+        if not m:
+            # Some shared objs might have no DT_NEEDED tags (see issue #67)
+            if line == '\tstatically linked':
+                break
+            raise LddError("Unexpected line in ldd output: " + line)
+        libname  = m.group(1)
+        libpath  = m.group(2)
+        baseaddr = int(m.group(3), 16)
+
+        if libname.startswith('/'):
+            # An absolute path here is probably INTERP
+            # and ldd shouldn't output the => /abs/path part.
+            if libpath:
+                raise LddError("Unexpected line in ldd output: " + line)
+            yield libname
+        else:
+            # A short libname should come from a NEEDED tag
+            # and ldd should include the => /abs/path part.
+            # If it doesn't, then it's probably linux-vdso*.so
+            # or linux-gate.so
+            if not libpath:
+                # TODO: This check could be removed/relaxed
+                if libname.startswith('linux-'):
+                    continue
+                raise LddError("Unexpected line in ldd output: " + line)
+            yield libpath
+
+
 def get_shobj_deps(path, libpath=[]):
     """Discover the dependencies of a shared object (*.so file)
     """
@@ -120,46 +159,7 @@ def get_shobj_deps(path, libpath=[]):
         # We simply raise a specific exception and let the caller deal with it.
         raise LddError("Unexpected ldd error ({}): {}".format(rc, output))
 
-
-    # Example:
-    #	linux-vdso.so.1 (0x00007ffe53551000)
-    #     or
-    #	linux-vdso.so.1 =>  (0x00007ffe53551000)
-    #	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f42ac010000)
-    #	/lib64/ld-linux-x86-64.so.2 (0x0000557376e75000)
-    pat = re.compile(r'\t([\w./+-]*) (?:=> ([\w./+-]*) )?\((0x[0-9a-fA-F]*)\)')
-
-    def parse():
-        for line in output.splitlines():
-            m = pat.match(line)
-            if not m:
-                # Some shared objs might have no DT_NEEDED tags (see issue #67)
-                if line == '\tstatically linked':
-                    break
-                raise LddError("Unexpected line in ldd output: " + line)
-            libname  = m.group(1)
-            libpath  = m.group(2)
-            baseaddr = int(m.group(3), 16)
-
-            if libname.startswith('/'):
-                # An absolute path here is probably INTERP
-                # and ldd shouldn't output the => /abs/path part.
-                if libpath:
-                    raise LddError("Unexpected line in ldd output: " + line)
-                yield libname
-            else:
-                # A short libname should come from a NEEDED tag
-                # and ldd should include the => /abs/path part.
-                # If it doesn't, then it's probably linux-vdso*.so
-                # or linux-gate.so
-                if not libpath:
-                    # TODO: This check could be removed/relaxed
-                    if libname.startswith('linux-'):
-                        continue
-                    raise LddError("Unexpected line in ldd output: " + line)
-                yield libpath
-
-    return list(parse())
+    return list(_parse_ldd_output(output))
 
 
 

--- a/unittest/test_elf.py
+++ b/unittest/test_elf.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from staticx import elf
+
+class TestLdd:
+    def _test(self, output, exp):
+        res = list(elf._parse_ldd_output(output))
+        assert res == exp 
+
+    def test_ubuntu_1604(self):
+        # https://github.com/JonathonReinhart/staticx/pull/102#issuecomment-569874924
+        output = (
+            "\tlinux-vdso.so.1 =>  (0x00007ffdacbdd000)\n"
+	    "\tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f03d10aa000)\n"
+	    "\t/lib64/ld-linux-x86-64.so.2 (0x00007f03d1474000)\n")
+        exp = [
+	    "/lib/x86_64-linux-gnu/libc.so.6",
+	    "/lib64/ld-linux-x86-64.so.2",
+        ]
+        self._test(output, exp)
+
+    def test_ubuntu_1604_i386(self):
+        output = (
+	    "\tlinux-gate.so.1 =>  (0xf7ef7000)\n"
+	    "\tlibc.so.6 => /lib/i386-linux-gnu/libc.so.6 (0xf7d3b000)\n"
+	    "\t/lib/ld-linux.so.2 (0xf7ef9000)\n")
+        exp = [
+	    "/lib/i386-linux-gnu/libc.so.6",
+	    "/lib/ld-linux.so.2",
+        ]
+        self._test(output, exp)
+
+    def test_debian_10(self):
+        output = (
+	    "\tlinux-vdso.so.1 (0x00007fff413cf000)\n"
+	    "\tlibc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6916ead000)\n"
+            "\t/lib64/ld-linux-x86-64.so.2 (0x00007f69170a7000)\n")
+        exp = [
+            "/lib/x86_64-linux-gnu/libc.so.6",
+            "/lib64/ld-linux-x86-64.so.2",
+        ]
+        self._test(output, exp)


### PR DESCRIPTION
This adds a unit test for `ldd` output parsing, and makes it easy to add additional tests in the future.

Makes progress towards #27 