### PR TITLE
Fix NULL tmpdir error message

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -205,10 +205,11 @@ patch_app(const char *prog_path)
 static char *
 create_tmpdir(void)
 {
-    char *template = path_join(getenv(TMPDIR) ?: "/tmp", "staticx-XXXXXX");
+    const char *tmproot = getenv(TMPDIR) ?: "/tmp";
+    char *template = path_join(tmproot, "staticx-XXXXXX");
     char *tmpdir = mkdtemp(template);
     if (!tmpdir)
-        error(2, errno, "Failed to create temporary directory: %s", tmpdir);
+        error(2, errno, "Failed to create temporary directory in %s", tmproot);
     assert(tmpdir == template);
     return tmpdir;
 }


### PR DESCRIPTION
Introduced in ba6e752

Fixes #119

Tested against GCC9

```
$ staticx $(which date) date.sx
$ ./date.sx
Wed 29 Jan 2020 07:35:20 AM EST
$ TMPDIR=/nonexist ./date.sx
date.sx: Failed to create temporary directory in /nonexist: No such file or directory
```