### PR TITLE
Fix ldd "you do not have execution..." warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Correct handling of absolute path symlink in ldd output ([#118])
 - Fixed null tmpdir argument error on GCC9 ([#120])
+- Fixed ldd "you do not have execution permission..." warning ([#122])
 
 
 ## [0.9.0] - 2020-01-11
@@ -156,3 +157,4 @@ Initial release
 [#112]: https://github.com/JonathonReinhart/staticx/pull/112
 [#118]: https://github.com/JonathonReinhart/staticx/pull/118
 [#120]: https://github.com/JonathonReinhart/staticx/pull/120
+[#122]: https://github.com/JonathonReinhart/staticx/pull/122

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -10,7 +10,7 @@ def make_mode_executable(mode):
 
 def make_executable(path):
     mode = os.stat(path).st_mode
-    make_mode_executable(mode)
+    mode = make_mode_executable(mode)
     os.chmod(path, mode)
 
 def get_symlink_target(path):

--- a/unittest/test_utils.py
+++ b/unittest/test_utils.py
@@ -1,0 +1,10 @@
+import tempfile
+import os
+
+from staticx import utils
+
+def test_make_executable():
+    with tempfile.NamedTemporaryFile() as tf:
+        assert (os.stat(tf.name).st_mode & 0o111) == 0
+        utils.make_executable(tf.name)
+        assert (os.stat(tf.name).st_mode & 0o111) != 0


### PR DESCRIPTION
This fixes these warnings from `ldd`:
```
ldd: warning: you do not have execution permission for `/tmp/staticx-pyi-fe35tk1i/_asyncio.cpython-38-x86_64-linux-gnu.so'
```

There was code to handle this, but this bug was introduced in 2d31b398 when `make_executable` stopped having any effect.