### PR TITLE
Optimize libtar extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Improved tar extraction to minimize number of write() calls ([#131])
+
+
 ## [0.10.0] - 2020-05-30
 ### Added
 - Added `sx-extract` archive extraction/dumping tool ([#114])
@@ -170,3 +175,4 @@ Initial release
 [#118]: https://github.com/JonathonReinhart/staticx/pull/118
 [#120]: https://github.com/JonathonReinhart/staticx/pull/120
 [#122]: https://github.com/JonathonReinhart/staticx/pull/122
+[#131]: https://github.com/JonathonReinhart/staticx/pull/131

--- a/libtar/block.c
+++ b/libtar/block.c
@@ -28,7 +28,7 @@ th_read_internal(TAR *t)
 	int num_zero_blocks = 0;
 
 #ifdef DEBUG
-	printf("==> th_read_internal(TAR=\"%s\")\n", t->pathname);
+	printf("==> th_read_internal(t=%p)\n", t);
 #endif
 
 	while ((i = tar_block_read(t, &(t->th_buf))) == T_BLOCKSIZE)

--- a/libtar/extract.c
+++ b/libtar/extract.c
@@ -259,36 +259,6 @@ tar_extract_regfile(TAR *t, const char *realname)
 }
 
 
-/* skip regfile */
-int
-tar_skip_regfile(TAR *t)
-{
-	int i, k;
-	size_t size;
-	char buf[T_BLOCKSIZE];
-
-	if (!TH_ISREG(t))
-	{
-		errno = EINVAL;
-		return -1;
-	}
-
-	size = th_get_size(t);
-	for (i = size; i > 0; i -= T_BLOCKSIZE)
-	{
-		k = tar_block_read(t, buf);
-		if (k != T_BLOCKSIZE)
-		{
-			if (k != -1)
-				errno = EINVAL;
-			return -1;
-		}
-	}
-
-	return 0;
-}
-
-
 /* hardlink */
 int
 tar_extract_hardlink(TAR * t, const char *realname)

--- a/libtar/libtar.h
+++ b/libtar/libtar.h
@@ -169,7 +169,6 @@ int tar_extract_fifo(TAR *t, const char *realname);
 
 /* for regfiles, we need to extract the content blocks as well */
 int tar_extract_regfile(TAR *t, const char *realname);
-int tar_skip_regfile(TAR *t);
 
 
 /***** output.c ************************************************************/


### PR DESCRIPTION
This updates `tar_extract_regfile()` to make a single `write()` syscall, rather than writing 512 bytes at a time.

Closes #130 


```
strace -c ./id-dev.sx 
uid=1000(jreinhart) gid=1000(jreinhart) groups=1000(jreinhart),...
% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
 31.61    0.000325          46         7           write
 17.12    0.000176           8        20         7 unlink
  7.59    0.000078           1        51           open
  6.23    0.000064           1        63           close
  6.03    0.000062           0        74           read
  5.54    0.000057           0        81           fcntl
  3.31    0.000034          34         1           rmdir
  3.21    0.000033           2        12        12 connect
  3.02    0.000031           5         6           symlink
  2.53    0.000026           5         5           munmap
  2.24    0.000023           7         3           madvise
  2.14    0.000022           0        27        26 mkdir
  1.85    0.000019           0        28           lseek
  1.85    0.000019           1        12           socket
  1.36    0.000014           2         7           utimensat
  0.97    0.000010           1         7           chmod
  0.68    0.000007           0        13           geteuid
  0.68    0.000007           3         2           getdents64
  0.49    0.000005           0         6           mmap
  0.49    0.000005           5         1           fork
  0.29    0.000003           0        14           lstat
  0.29    0.000003           0         4           rt_sigaction
  0.19    0.000002           2         1           wait4
  0.10    0.000001           1         1           stat
  0.10    0.000001           1         1           access
  0.10    0.000001           1         1           readlink
  0.00    0.000000           0         3           fstat
  0.00    0.000000           0         6           brk
  0.00    0.000000           0         3           rt_sigprocmask
  0.00    0.000000           0         1           execve
  0.00    0.000000           0         1           arch_prctl
  0.00    0.000000           0         1           set_tid_address
------ ----------- ----------- --------- --------- ----------------
100.00    0.001028                   463        45 total
```

My unscientific test shows the total `write` going:

- Before: 5517 calls, total 0.009341 sec
- After: 7 calls, total 0.000325 sec (-96.5% :tada:)