### PR TITLE
Reorganize the way the bootloader is accessed

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -23,7 +23,6 @@ base_env['CC'] = ARGUMENTS.get('CC') or os.environ.get('CC') or base_env['CC']
 # Setup Release environment
 release_env = base_env.Clone(
     MODE = 'release',
-    BOOTLOADER_NAME = 'bootloader',
 )
 release_env.Append(
     CPPDEFINES = {'NDEBUG': 1},
@@ -33,7 +32,6 @@ release_env.Append(
 # Setup Debug environment
 debug_env = base_env.Clone(
     MODE = 'debug',
-    BOOTLOADER_NAME = 'bootloader-debug',
 )
 debug_env.Append(
     CPPDEFINES = {'DEBUG': 1},
@@ -65,4 +63,4 @@ for env in (release_env, debug_env):
         duplicate = False,
         exports = dict(env=env.Clone()),
     )
-    env.InstallAs('#staticx/$BOOTLOADER_NAME', bl)
+    env.InstallAs('#staticx/assets/$MODE/bootloader', bl)

--- a/setup.py
+++ b/setup.py
@@ -71,10 +71,7 @@ setup(
     url = 'https://github.com/JonathonReinhart/staticx',
     packages = find_packages(),
     package_data = {
-        'staticx': [
-            'bootloader',
-            'bootloader-debug',
-        ],
+        'staticx': ['assets/*/*'],
     },
 
     # Ugh.

--- a/staticx/.gitignore
+++ b/staticx/.gitignore
@@ -1,2 +1,1 @@
-/bootloader
-/bootloader-debug
+/assets

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -32,8 +32,6 @@ def parse_args():
             help = 'Set the logging level (default: {})'.format(DEFAULT_LOGLEVEL))
 
     # Hidden arguments (for development / testing)
-    ap.add_argument('--bootloader',
-            help = argparse.SUPPRESS)
     ap.add_argument('--debug', action='store_true',
             help = argparse.SUPPRESS)
 
@@ -52,7 +50,6 @@ def main():
     try:
         generate(args.prog, args.output,
                 libs = args.libs,
-                bootloader = args.bootloader,
                 strip = args.strip,
                 compress = not args.no_compress,
                 debug = args.debug,

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -64,14 +64,19 @@ def generate_archive(orig_prog, copied_prog, interp, tmpdir, extra_libs=None, st
     f.flush()
     return f
 
+
+def _locate_asset(name, debug):
+    pkg_path = os.path.dirname(__file__)
+    mode = 'debug' if debug else 'release'
+    path = os.path.abspath(os.path.join(pkg_path, 'assets', mode, name))
+    if not os.path.isfile(path):
+        raise InternalError("Asset not found at {}".format(path))
+    return path
+
+
 def _locate_bootloader(debug=False):
     """Determine path to bootloader"""
-    pkg_path = os.path.dirname(__file__)
-    blname = 'bootloader-debug' if debug else 'bootloader'
-    blpath = os.path.abspath(os.path.join(pkg_path, blname))
-    if not os.path.isfile(blpath):
-        raise InternalError("bootloader not found at {}".format(blpath))
-    return blpath
+    return _locate_asset('bootloader', debug)
 
 
 def _check_bootloader_compat(bootloader, prog):

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -93,19 +93,17 @@ def _copy_to_tempfile(srcpath, **kwargs):
     return fdst
 
 
-def generate(prog, output, libs=None, bootloader=None, strip=False, compress=True, debug=False):
+def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
     """Main API: Generate a staticx executable
 
     Parameters:
     prog:   Dynamic executable to staticx
     output: Path to result
     libs: Extra libraries to include
-    bootloader: Override the bootloader binary
     strip: Strip binaries to reduce size
     debug: Run in debug mode (use debug bootloader)
     """
-    if not bootloader:
-        bootloader = _locate_bootloader(debug)
+    bootloader = _locate_bootloader(debug)
     _check_bootloader_compat(bootloader, prog)
 
 

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -17,7 +17,7 @@ from .assets import copy_asset_to_tempfile
 from .constants import *
 from .hooks import run_hooks
 
-def generate_archive(orig_prog, copied_prog, interp, tmpdir, extra_libs=None, strip=False, compress=True):
+def generate_archive(orig_prog, copied_prog, interp, tmpdir, extra_libs=None, strip=False, compress=True, debug=False):
     """ Generate a StaticX archive
 
     Args:
@@ -60,7 +60,11 @@ def generate_archive(orig_prog, copied_prog, interp, tmpdir, extra_libs=None, st
             # Add the library to the archive
             ar.add_library(libpath)
 
-        run_hooks(ar, orig_prog)
+        run_hooks(
+                archive = ar,
+                program = orig_prog,
+                debug = debug,
+                )
 
     f.flush()
     return f
@@ -127,7 +131,8 @@ def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
 
         # Starting from the bootloader, append archive
         tmpdir = mkdtemp(prefix='staticx-archive-')
-        with generate_archive(prog, tmpprog, orig_interp, tmpdir, libs, strip=strip, compress=compress) as ar:
+        with generate_archive(prog, tmpprog, orig_interp, tmpdir, libs,
+                strip=strip, compress=compress, debug=debug) as ar:
             elf_add_section(tmpoutput, ARCHIVE_SECTION, ar.name)
 
         # Move the temporary output file to its final place

--- a/staticx/assets.py
+++ b/staticx/assets.py
@@ -1,0 +1,15 @@
+import pkg_resources
+from .utils import copy_fileobj_to_tempfile
+
+def locate_asset(name, debug):
+    mode = 'debug' if debug else 'release'
+    path = '/'.join(('assets', mode, name))
+    try:
+        return pkg_resources.resource_stream(__name__, path)
+    except FileNotFoundError:
+        raise KeyError("Asset not found: {!r} (mode={!r})".format(name, mode))
+
+
+def copy_asset_to_tempfile(assetname, debug, **kwargs):
+    with locate_asset(assetname, debug) as fsrc:
+        return copy_fileobj_to_tempfile(fsrc, **kwargs)

--- a/staticx/hooks/__init__.py
+++ b/staticx/hooks/__init__.py
@@ -4,6 +4,13 @@ hooks = [
     process_pyinstaller_archive,
 ]
 
-def run_hooks(ar, prog):
+
+class HookContext:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+def run_hooks(**kw):
+    ctx = HookContext(**kw)
     for hook in hooks:
-        hook(ar, prog)
+        hook(ctx)

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -5,7 +5,7 @@ import tempfile
 from ..elf import get_shobj_deps, StaticELFError, LddError
 from ..utils import make_executable, mkdirs_for
 
-def process_pyinstaller_archive(sx_ar, prog):
+def process_pyinstaller_archive(ctx):
     # See utils/cliutils/archive_viewer.py
 
     # If PyInstaller is not installed, do nothing
@@ -16,13 +16,13 @@ def process_pyinstaller_archive(sx_ar, prog):
 
     # Attempt to open the program as PyInstaller archive
     try:
-        pyi_ar = CArchiveReader(prog)
+        pyi_ar = CArchiveReader(ctx.program)
     except:
         # Silence all PyInstaller exceptions here
         return
     logging.info("Opened PyInstaller archive!")
 
-    with PyInstallHook(sx_ar, pyi_ar) as h:
+    with PyInstallHook(ctx.archive, pyi_ar) as h:
         h.process()
 
 

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -1,6 +1,7 @@
 import os
 import errno
 import shutil
+from tempfile import NamedTemporaryFile
 from .errors import *
 
 def make_mode_executable(mode):
@@ -26,3 +27,18 @@ def move_file(src, dst):
 def mkdirs_for(filename):
     dirname = os.path.dirname(filename)
     os.makedirs(dirname, exist_ok=True)
+
+
+def copy_to_tempfile(srcpath, **kwargs):
+    with open(srcpath, 'rb') as fsrc:
+        fdst = copy_fileobj_to_tempfile(fsrc, **kwargs)
+
+    shutil.copystat(srcpath, fdst.name)
+    return fdst
+
+
+def copy_fileobj_to_tempfile(fsrc, **kwargs):
+    fdst = NamedTemporaryFile(**kwargs)
+    shutil.copyfileobj(fsrc, fdst)
+    fdst.flush()
+    return fdst


### PR DESCRIPTION
This is in preparation for #129.

1. Move to `assets/$MODE/bootloader`
2. Use `pkg_resources.resource_stream`
3. Rework `SConstruct` to improve clarity / extensibility
4. Rework hook API to improve extensibility