### PR TITLE
Remove more Python 2.7 compatibility cruft

### DIFF
--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -34,7 +34,7 @@ def get_xz_filters():
     filters.append(dict(id=lzma.FILTER_LZMA2))
     return filters
 
-class SxArchive(object):
+class SxArchive:
     def __init__(self, fileobj, mode, compress):
         self.xzf = None
 

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -12,7 +12,7 @@ from elftools.common.exceptions import ELFError
 from .errors import *
 from .utils import coerce_sequence
 
-class ExternTool(object):
+class ExternTool:
     def __init__(self, cmd, os_pkg, stderr_ignore=[], encoding='utf-8'):
         self.cmd = cmd
         self.os_pkg = os_pkg
@@ -218,7 +218,7 @@ class StaticELFError(Error):
         super().__init__(message)
 
 
-class ELFCloser(object):
+class ELFCloser:
     def __init__(self, path, mode):
         self.f = open(path, mode)
         self.elf = ELFFile(self.f)

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -80,7 +80,7 @@ tool_strip      = ExternTool('strip', 'binutils')
 
 class LddError(ToolError):
     def __init__(self, message):
-        super(LddError, self).__init__('ldd', message)
+        super().__init__('ldd', message)
 
 
 def _parse_ldd_output(output):
@@ -217,7 +217,7 @@ class StaticELFError(Error):
     """Dynamic operation requested on static executable"""
     def __init__(self, path):
         message = "{} is a static ELF file".format(path)
-        super(StaticELFError, self).__init__(message)
+        super().__init__(message)
 
 
 class ELFCloser(object):

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -37,10 +37,8 @@ class ExternTool(object):
         logging.debug("Running " + str(args))
         try:
             return subprocess.Popen(args, **kw)
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                raise MissingToolError(self.cmd, self.os_pkg)
-            raise
+        except FileNotFoundError:
+            raise MissingToolError(self.cmd, self.os_pkg)
 
 
     def run(self, *args, **kw):

--- a/staticx/errors.py
+++ b/staticx/errors.py
@@ -10,13 +10,13 @@ class InternalError(Error):
 class ToolError(Error):
     """An external tool indicated an error"""
     def __init__(self, program, message=None):
-        super(ToolError,self).__init__(message or "'{}' failed".format(program))
+        super().__init__(message or "'{}' failed".format(program))
         self.program = program
 
 class MissingToolError(Error):
     """A required external tool is missing"""
     def __init__(self, program, package):
-        super(MissingToolError, self).__init__("Couldn't find '{}'. Is '{}' installed?".format(
+        super().__init__("Couldn't find '{}'. Is '{}' installed?".format(
             program, package))
         self.program = program
         self.package = package
@@ -36,7 +36,7 @@ class ArchiveError(Error):
 class LibExistsError(ArchiveError):
     """Given library already exists in archive"""
     def __init__(self, lib):
-        super(LibExistsError, self).__init__(
+        super().__init__(
                 "Library '{}' already exists in archive".format(lib))
         self.lib = lib
 
@@ -44,6 +44,6 @@ class LibExistsError(ArchiveError):
 class DirectoryExistsError(Error):
     """A given directory already exists"""
     def __init__(self, path):
-        super(DirectoryExistsError, self).__init__(
+        super().__init__(
                 "{}: is a directory".format(path))
         self.path = path

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -27,8 +27,7 @@ def process_pyinstaller_archive(ctx):
 
 
 
-class PyInstallHook(object):
-
+class PyInstallHook:
     def __init__(self, sx_archive, pyi_archive):
         self.sx_ar = sx_archive
         self.pyi_ar = pyi_archive


### PR DESCRIPTION
This removes some more remnants of Python 2.7 compatibility and uses more Python 3 features:
- Effectively revert the remnants of 0d659d9214cb604c2ab3d33706aba7208641fea2:
  - Python 3 `super`: `super(Foo, self)` --> `super()`
  - Use `FileNotFoundError` instead of `OSError` + `e.errno == errno.ENOENT`:
- Use Python 3 new-style classes: `class Foo(object):` --> `class Foo:`
- Use `subprocess.run()`