### PR TITLE
Fix bootloader for native 32-bit builds

### DIFF
--- a/bootloader/elfutil.h
+++ b/bootloader/elfutil.h
@@ -3,11 +3,28 @@
 
 #include <elf.h>
 #include <stdbool.h>
+#include <stdint.h>
 
-#define Elf_Ehdr    Elf64_Ehdr
-#define Elf_Phdr    Elf64_Phdr
-#define Elf_Shdr    Elf64_Shdr
-#define Elf_Dyn     Elf64_Dyn
+/**
+ * Determine native ELF type by looking at size of pointer.
+ * This should work even for x32 which uses elf32:
+ * https://stackoverflow.com/a/36347228
+ */
+#if UINTPTR_MAX == UINT64_MAX
+/* 64-bit */
+# define Elf_Ehdr    Elf64_Ehdr
+# define Elf_Phdr    Elf64_Phdr
+# define Elf_Shdr    Elf64_Shdr
+# define Elf_Dyn     Elf64_Dyn
+#elif UINTPTR_MAX == UINT32_MAX
+/* 32-bit */
+# define Elf_Ehdr    Elf32_Ehdr
+# define Elf_Phdr    Elf32_Phdr
+# define Elf_Shdr    Elf32_Shdr
+# define Elf_Dyn     Elf32_Dyn
+#else
+# error unexpected UINTPTR_MAX
+#endif
 
 bool
 elf_is_valid(const Elf_Ehdr *ehdr);

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <inttypes.h>
 #include <string.h>
 #include <errno.h>
 #include <assert.h>
@@ -160,7 +162,8 @@ dyn_done:
         error(2, 0, "RPATH outside of dynamic strtab!");
     char *rpath = ptr_add(dynstrtab, dt_rpath->d_un.d_val);
 
-    debug_printf("Current RPATH (0x%lX): \"%s\"\n", dt_rpath->d_un.d_val,
+    debug_printf("Current RPATH (0x%"PRIXPTR"): \"%s\"\n",
+            (uintptr_t)dt_rpath->d_un.d_val,
             fmt_str_rep(rpath));
 
     /* Set new RPATH */


### PR DESCRIPTION
This MR adds unofficial support for StaticX in native 32-bit (e.g. i386) environments. It does *not* address "multiarch" environments (#55).

I say "unofficial" because Travis doesn't support 32-bit environments, and I haven't yet  moved away from Travis (#124).

Fixes #144