### PR TITLE
setup.py: Override plat_name for bdist_wheel to manylinux1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ script:
 
   # Build and install a wheel
   - python setup.py bdist_wheel
-  - pip install dist/staticx-*-py3-none-any.whl
+  - pip install dist/staticx-*-py3-none-manylinux1_x86_64.whl
   - staticx --version
 
   # Run unit tests

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # Derived from https://github.com/JonathonReinhart/scuba
 from setuptools import setup, Command, find_packages
+from wheel.bdist_wheel import bdist_wheel
 from distutils.command.build import build
 import os
+import sys
 from subprocess import check_call
 
 from dynversion import get_dynamic_version
@@ -29,6 +31,66 @@ class build_hook(build):
         self.run_command('build_bootloader')
         build.run(self)
 
+
+class bdist_wheel_hook(bdist_wheel):
+    def finalize_options(self):
+        self.plat_name = get_platform()     # Equivalent to passing --plat-name
+        super().finalize_options()
+
+
+class UnsupportedPlatformError(Exception):
+    pass
+
+def get_platform():
+    """Get platform string (e.g. "manylinux1_x86_64")
+
+    Staticx itself is a pure python package, but it includes binary assets
+    which are OS/machine dependent. Thus, staticx wheels shouldn't be tagged
+    with platform of "any", which is the default behavior when setup.py doesn't
+    include any Python extensions.
+
+    There are various ways to change this behavior, none of which works well
+    for staticx:
+    1) Pass --plat-name to `setup.py bdist_wheel`.
+       This gets in the way of external tooling (e.g. Travis 'deploy')
+    2) Include a dummy Extension: https://stackoverflow.com/a/53463910
+       This causes undue problems becuase it sets the Python ABI field also,
+       which staticx doesn't care about.
+
+    So instead, we take care of it ourselves.
+
+    While staticx isn't really built in the typical 'manylinux1' fashion,
+    it identifies as 'manylinux1' for PyPI binary wheel compatibility.
+
+    Rationale: staticx assets follow stricter compatibility rules than
+    manylinux1:
+    - bootloader is statically-linked
+    - libnsskill.so is GLIBC-specific and version-agnostic
+    """
+    uname = os.uname()
+
+    # Apply the same conversions as distutils.util.get_platform()
+    osname = uname.sysname.lower().replace('/', '')
+    machine = uname.machine.replace(' ', '_').replace('/', '-')
+
+    # Check compatibility
+    if osname != "linux":
+        # Right now staticx only supports Linux
+        raise UnsupportedPlatformError("OS {!r} unsupported by staticx".format(osname))
+
+    # Adjust machine if necessary
+    #
+    # This applies to a 32-bit Python interpreter running on a 64-bit kernel.
+    # We assume that the compiler is also targetting 32-bit, otherwise Python
+    # won't match the UINTPTR_MAX check in bootloader/elfutil.h
+    #
+    # See:
+    #   https://github.com/pypa/pip/pull/3497#discussion_r54870308
+    #   https://github.com/pypa/wheel/commit/b9dbb6fa257c
+    if machine == "x86_64" and sys.maxsize == 0x7fffffff:
+        machine = "i686"
+
+    return 'manylinux1_{}'.format(machine)
 
 ################################################################################
 
@@ -93,5 +155,6 @@ setup(
     cmdclass = {
         'build_bootloader': build_bootloader,
         'build':            build_hook,
+        'bdist_wheel':      bdist_wheel_hook,
     },
 )


### PR DESCRIPTION
Indicate that we are effectively "manylinux1" compliant, even though we don't build with their tools, we have static Linux assets which are OS and machine dependent.

Fixes #150

---

Thinking ahead, #55 gets even more complicated because if we include bootloaders for `i386` and `x86_64` (any maybe even other architectures!) then our wheel would be better described as `manylinux1_any`, which isn't valid.