### PR TITLE
Fix broken source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,7 @@
 graft bootloader
 graft libtar
 graft libxz
+graft libnssfix
 include SConstruct
+graft site_scons
+global-exclude *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ graft libtar
 graft libxz
 graft libnssfix
 include SConstruct
+include dynversion.py
 graft site_scons
 global-exclude *.py[cod]


### PR DESCRIPTION
There were entries missing from `MANIFEST.in`:
- #139 forgot to add `libnssfix/` and `site_scons/`
- 3bdff7c forgot to add `dynversion.py`

Closes #152