### PR TITLE
Change SCons to execute dynversion.py instead of importing it

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3,6 +3,11 @@ import os
 
 from conftest import custom_tests
 
+def _get_sx_version():
+    import subprocess
+    args = ['python3', 'dynversion.py']
+    return subprocess.check_output(args).strip()
+
 # Set up base environment
 base_env = Environment(
     CCFLAGS = [
@@ -13,7 +18,11 @@ base_env = Environment(
     BUILD_ROOT = '#scons_build',
     BUILD_DIR = '$BUILD_ROOT/$MODE',
     LIBDIR = '$BUILD_DIR/lib',
-    LIBPATH = '$LIBDIR'
+    LIBPATH = '$LIBDIR',
+    STATICX_VERSION = _get_sx_version(),
+    CPPDEFINES = dict(
+        STATICX_VERSION = '\\"$STATICX_VERSION\\"',
+    ),
 )
 
 def get_anywhere(env, what, default=None):

--- a/bootloader/SConscript
+++ b/bootloader/SConscript
@@ -2,17 +2,9 @@ import sys
 
 Import('env')
 
-projdir = env.Dir('.').srcnode().dir
-sys.path.append(projdir)
-from dynversion import get_dynamic_version
-
-
 env.Append(
     CCFLAGS = ['-static'],
     LINKFLAGS = ['-static'],
-    CPPDEFINES = dict(
-        STATICX_VERSION = '\\"{}\\"'.format(get_dynamic_version()),
-    ),
     CPPPATH = [
         '#libtar',
         '#libxz',

--- a/dynversion.py
+++ b/dynversion.py
@@ -13,3 +13,6 @@ def get_dynamic_version():
         return '{}.{}'.format(staticx.version.BASE_VERSION, build_num)
 
     return staticx.version.__version__
+
+if __name__ == '__main__':
+    print(get_dynamic_version())


### PR DESCRIPTION
Fixes #155

This generally decouples the SCons Python environment from the setup.py environment.
