### PR TITLE
Fix bug where SCons v4.1.0 causes libnssfix to be built incorrectly.

### DIFF
--- a/site_scons/site_tools/stubgen.py
+++ b/site_scons/site_tools/stubgen.py
@@ -37,7 +37,7 @@ def ShlibStubGen(env, target, symbols):
             '-fno-builtin',
         ],
         LINKFLAGS = env['LINKFLAGS'] + [
-            '-Wl,-soname=$_SHLIBSONAME',
+            '-Wl,-soname=${TARGET.name}',
             '-nostdlib',
         ],
         SHLIBSUFFIX='',


### PR DESCRIPTION
Fixes #167.