### PR TITLE
Pin pyinstaller at 4.0 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # These requirements are in addition to install_requires from setup.py
 # and are only used for development and testing.
 patchelf-wrapper
-pyinstaller; (python_version <= '3.7')
+pyinstaller==4.0; (python_version <= '3.7')
 
 # https://github.com/pypa/setuptools/issues/1963
 # Exclude from 45.0.0 until 49.1.1


### PR DESCRIPTION
This is a quick fix for the CI test failures associated with  #170