### PR TITLE
Issue with glibc hook

### DIFF
--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -251,7 +251,7 @@ def get_section(elf, sectype):
     for sec in elf.iter_sections():
         if isinstance(sec, sectype):
             return sec
-    return KeyError("Can't find section of type {}".format(sectype))
+    raise KeyError("Can't find section of type {}".format(sectype))
 
 
 def get_machine(path):

--- a/staticx/hooks/glibc.py
+++ b/staticx/hooks/glibc.py
@@ -36,13 +36,15 @@ def process_glibc_prog(ctx):
 
 def is_linked_against_glibc(prog):
     with open_elf(prog) as elf:
-        sec = get_section(elf, GNUVerNeedSection)
-        for verneed, vernaux_iter in sec.iter_versions():
-            if not verneed.name.startswith('libc.so'):
-                continue
-            for vernaux in vernaux_iter:
-                if vernaux.name.startswith('GLIBC_'):
-                    logging.debug("Program linked with GLIBC: Found {} {}".format(
-                        verneed.name, vernaux.name))
-                    return True
-    return False
+        try:
+            sec = get_section(elf, GNUVerNeedSection)
+            for verneed, vernaux_iter in sec.iter_versions():
+                if not verneed.name.startswith('libc.so'):
+                    continue
+                for vernaux in vernaux_iter:
+                    if vernaux.name.startswith('GLIBC_'):
+                        logging.debug("Program linked with GLIBC: Found {} {}".format(
+                            verneed.name, vernaux.name))
+                        return True
+        except KeyError:
+            return False


### PR DESCRIPTION
Came across this on alpine linux where my ELF files didn't have a `GNUVerNeedSection`.  Changed elf.py -> get_section to raise the KeyError instead of return it. And changed the glibc hook to handle the exception (might not be the best way, but it fixed my problem on alpine)