### PR TITLE
Fix issue with get_section() erroneously returning KeyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Worked around patchelf bug which caused `Couldn't find DT_RPATH tag`
   error at runtime ([#175])
+- Fixed a bug which caused the glibc hook to crash on non-glibc
+  executables ([#179])
 
 
 ## [0.12.1] - 2021-02-06
@@ -225,3 +227,4 @@ Initial release
 [#157]: https://github.com/JonathonReinhart/staticx/pull/157
 [#168]: https://github.com/JonathonReinhart/staticx/pull/168
 [#175]: https://github.com/JonathonReinhart/staticx/pull/175
+[#179]: https://github.com/JonathonReinhart/staticx/pull/179

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -251,7 +251,7 @@ def get_section(elf, sectype):
     for sec in elf.iter_sections():
         if isinstance(sec, sectype):
             return sec
-    return KeyError("Can't find section of type {}".format(sectype))
+    return None
 
 
 def get_machine(path):

--- a/staticx/hooks/glibc.py
+++ b/staticx/hooks/glibc.py
@@ -37,6 +37,8 @@ def process_glibc_prog(ctx):
 def is_linked_against_glibc(prog):
     with open_elf(prog) as elf:
         sec = get_section(elf, GNUVerNeedSection)
+        if not sec:
+            return False
         for verneed, vernaux_iter in sec.iter_versions():
             if not verneed.name.startswith('libc.so'):
                 continue


### PR DESCRIPTION
This fixes the bug introduced in #139, by returning `None` and handling that in the only consumer.

I want to add a test that covers this but it is difficult:
- Unit test: It's a pain in the ass to write unit tests which make assertions about ELF input files, without checking-in binaries, which I'm not a fan of.
- Integration test: I tried to test staticx against a musl-libc-linked executable, but it failed with #178.

I'd like to improve testing of staticx in lots of ways, but this PR clearly fixes the problem at hand.

Fixes #177  
Supersedes #176