### PR TITLE
Persist LD_LIBRARY_PATH when invoking ldd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `STATICX_LDD` environment variable to override the `ldd` executable
   used by Staticx to discover library dependencies. ([#180])
 
+### Changed
+- `LD_LIBRARY_PATH` enviroment variable is now maintained when invoking `ldd`
+  to discover dependencies ([#185])
+
 
 ## [0.12.2] - 2021-05-22
 ### Fixed
@@ -236,3 +240,4 @@ Initial release
 [#175]: https://github.com/JonathonReinhart/staticx/pull/175
 [#179]: https://github.com/JonathonReinhart/staticx/pull/179
 [#180]: https://github.com/JonathonReinhart/staticx/pull/180
+[#185]: https://github.com/JonathonReinhart/staticx/pull/185

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -136,10 +136,9 @@ def get_shobj_deps(path, libpath=[]):
     # First verify we're dealing with a dynamic ELF file
     ensure_dynamic(path)
 
-
-    # TODO: Should we use dict(os.environ) instead?
-    #       For now, make sure we always pass a clean environment.
-    env = {}
+    # Prepare the environment
+    keep_vars = {'LD_LIBRARY_PATH'}
+    env = {k:v for k,v in os.environ.items() if k in keep_vars}
 
     if libpath:
         # Prepend to LD_LIBRARY_PATH

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -129,7 +129,7 @@ def _parse_ldd_output(output):
         yield libpath
 
 
-def get_shobj_deps(path, libpath=[]):
+def get_shobj_deps(path, libpath=None):
     """Discover the dependencies of a shared object (*.so file)
     """
 


### PR DESCRIPTION
This fixes #184.