### PR TITLE
Refactor

### DIFF
--- a/staticx/api.py
+++ b/staticx/api.py
@@ -121,12 +121,7 @@ class StaticxGenerator:
         # Build the archive to be appended
         self.tmpdir = mkdtemp(prefix='staticx-archive-')
         with self.sxar as ar:
-            run_hooks(
-                    archive = ar,
-                    orig_prog = self.orig_prog,
-                    copied_prog = self.tmpprog,
-                    debug = self.debug,
-                    )
+            run_hooks(self)
 
             ar.add_program(self.tmpprog, basename(self.orig_prog))
             ar.add_interp_symlink(orig_interp)

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -7,7 +7,6 @@ from tempfile import NamedTemporaryFile, mkdtemp
 import os
 from os.path import basename
 import logging
-from itertools import chain
 
 from .errors import *
 from .utils import *
@@ -87,17 +86,12 @@ class StaticxGenerator:
 
 
 
-    def generate(self, output, extra_libs=None):
+    def generate(self, output):
         """Generate a Staticx program
 
         Parameters:
         output: Path where output file is written
-        extra_libs:   Extra libraries to include
         """
-        # TODO: Remove extra_libs and use an add_library() method
-        if extra_libs is None:
-            extra_libs = []
-
         # Only allow generate() to be called once per instance.
         # In the future we might relax this, but YAGNI for now.
         if self._generate_called:
@@ -138,7 +132,7 @@ class StaticxGenerator:
             ar.add_interp_symlink(orig_interp)
 
             # Add all of the libraries
-            for libpath in chain(get_shobj_deps(self.orig_prog), extra_libs):
+            for libpath in get_shobj_deps(self.orig_prog):
                 self.add_library(libpath, exist_ok=True)
 
         # errr...
@@ -210,4 +204,7 @@ def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
             debug=debug,
             )
     with gen:
-        gen.generate(output=output, extra_libs=libs)
+        for lib in (libs or []):
+            gen.add_library(lib)
+
+        gen.generate(output=output)

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -17,58 +17,7 @@ from .assets import copy_asset_to_tempfile
 from .constants import *
 from .hooks import run_hooks
 
-def generate_archive(orig_prog, copied_prog, interp, tmpdir, extra_libs=None, strip=False, compress=True, debug=False):
-    """ Generate a StaticX archive
 
-    Args:
-        orig_prog: Path to original user program
-        copied_prog: Path to user program which has been prepped
-        interp: Original program interpreter
-        tmpdir: Temporary directory to use for stripping libraries
-        extra_libs: Additional libraries to add to the archive
-        strip: Whether or not to strip libraries
-        compress: Whether or not to create a compressed archive
-
-    Returns:
-        A handle to the created file object
-    """
-    logging.info("Program interpreter: " + interp)
-
-    if extra_libs is None:
-        extra_libs = []
-
-    f = NamedTemporaryFile(prefix='staticx-archive-', suffix='.tar')
-    with SxArchive(fileobj=f, mode='w', compress=compress) as ar:
-        run_hooks(
-                archive = ar,
-                orig_prog = orig_prog,
-                copied_prog = copied_prog,
-                debug = debug,
-                )
-
-        ar.add_program(copied_prog, basename(orig_prog))
-        ar.add_interp_symlink(interp)
-
-        # Add all of the libraries
-        for libpath in chain(get_shobj_deps(orig_prog), extra_libs):
-            if strip:
-                # Copy the library to the temp dir before stripping
-                tmplib = os.path.join(tmpdir, basename(libpath))
-                logging.info("Copying {} to {}".format(libpath, tmplib))
-                shutil.copy(libpath, tmplib)
-
-                # Strip the library
-                logging.info("Stripping binary {}".format(tmplib))
-                strip_elf(tmplib)
-
-                libpath = tmplib
-
-            # Add the library to the archive
-            ar.add_library(libpath, exist_ok=True)
-
-
-    f.flush()
-    return f
 
 
 def _get_bootloader(debug=False):
@@ -166,8 +115,7 @@ class StaticxGenerator:
 
         # Starting from the bootloader, append archive
         self.tmpdir = mkdtemp(prefix='staticx-archive-')
-        with generate_archive(self.orig_prog, self.tmpprog, orig_interp, self.tmpdir, libs,
-                strip=self.strip, compress=self.compress, debug=self.debug) as ar:
+        with self._generate_archive(orig_interp, libs) as ar:
             elf_add_section(self.tmpoutput, ARCHIVE_SECTION, ar.name)
 
         # Move the temporary output file to its final place
@@ -190,6 +138,55 @@ class StaticxGenerator:
         new_rpath = 'r' * MAX_RPATH_LEN
         patch_elf(self.tmpprog, interpreter=new_interp, rpath=new_rpath,
                   force_rpath=True, no_default_lib=True)
+
+
+    def _generate_archive(self, interp, extra_libs=None):
+        """ Generate a StaticX archive
+
+        Args:
+            interp: Original program interpreter
+            extra_libs: Additional libraries to add to the archive
+
+        Returns:
+            A handle to the created file object
+        """
+        logging.info("Program interpreter: " + interp)
+
+        if extra_libs is None:
+            extra_libs = []
+
+        f = NamedTemporaryFile(prefix='staticx-archive-', suffix='.tar')
+        with SxArchive(fileobj=f, mode='w', compress=self.compress) as ar:
+            run_hooks(
+                    archive = ar,
+                    orig_prog = self.orig_prog,
+                    copied_prog = self.tmpprog,
+                    debug = self.debug,
+                    )
+
+            ar.add_program(self.tmpprog, basename(self.orig_prog))
+            ar.add_interp_symlink(interp)
+
+            # Add all of the libraries
+            for libpath in chain(get_shobj_deps(self.orig_prog), extra_libs):
+                if self.strip:
+                    # Copy the library to the temp dir before stripping
+                    tmplib = os.path.join(self.tmpdir, basename(libpath))
+                    logging.info("Copying {} to {}".format(libpath, tmplib))
+                    shutil.copy(libpath, tmplib)
+
+                    # Strip the library
+                    logging.info("Stripping binary {}".format(tmplib))
+                    strip_elf(tmplib)
+
+                    libpath = tmplib
+
+                # Add the library to the archive
+                ar.add_library(libpath, exist_ok=True)
+
+
+        f.flush()
+        return f
 
 
 def generate(prog, output, libs=None, strip=False, compress=True, debug=False):

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -36,6 +36,15 @@ def get_xz_filters():
 
 class SxArchive:
     def __init__(self, fileobj, mode, compress):
+        """Create a staticx archive
+
+        Parameters:
+        fileobj:    File object for the archive (not closed by this class)
+        mode:       Mode: 'r' (for reading) or 'w' (for writing)
+        compress:   Boolean: use xz compression or not
+        """
+        # Keep original fileobj arg for consumer convenience only, never closed
+        self.fileobj = fileobj
         self.xzf = None
 
         if compress:

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -70,9 +70,18 @@ class SxArchive:
         return self
 
     def __exit__(self, *excinfo):
-        self.tar.close()
+        self.close()
+
+    def close(self):
+        # Don't touch self.fileobj here
+
+        if self.tar:
+            self.tar.close()
+            self.tar = None
+
         if self.xzf:
             self.xzf.close()
+            self.xzf = None
 
 
     @property

--- a/staticx/hooks/__init__.py
+++ b/staticx/hooks/__init__.py
@@ -7,12 +7,6 @@ hooks = [
 ]
 
 
-class HookContext:
-    def __init__(self, **kw):
-        self.__dict__.update(kw)
-
-
-def run_hooks(**kw):
-    ctx = HookContext(**kw)
+def run_hooks(sx):
     for hook in hooks:
-        hook(ctx)
+        hook(sx)

--- a/staticx/hooks/glibc.py
+++ b/staticx/hooks/glibc.py
@@ -27,7 +27,7 @@ def process_glibc_prog(sx):
     # since we added the dependency on libnssfix to the user program above.
     # Even though dependency discovery runs after this hook, it necessarily
     # operates on the *original* executable and not the copied/modified one,
-    # so it doesn't see changes made here.
+    # (see dfa201b07e) so it doesn't see changes made here.
     with nssfix:
         # TODO: Don't use sxar
         sx.sxar.add_fileobj(LIBNSSFIX, nssfix)

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -5,7 +5,7 @@ import tempfile
 from ..elf import get_shobj_deps, StaticELFError, LddError
 from ..utils import make_executable, mkdirs_for
 
-def process_pyinstaller_archive(ctx):
+def process_pyinstaller_archive(sx):
     # See utils/cliutils/archive_viewer.py
 
     # If PyInstaller is not installed, do nothing
@@ -16,20 +16,20 @@ def process_pyinstaller_archive(ctx):
 
     # Attempt to open the program as PyInstaller archive
     try:
-        pyi_ar = CArchiveReader(ctx.orig_prog)
+        pyi_ar = CArchiveReader(sx.orig_prog)
     except:
         # Silence all PyInstaller exceptions here
         return
     logging.info("Opened PyInstaller archive!")
 
-    with PyInstallHook(ctx.archive, pyi_ar) as h:
+    with PyInstallHook(sx, pyi_ar) as h:
         h.process()
 
 
 
 class PyInstallHook:
-    def __init__(self, sx_archive, pyi_archive):
-        self.sx_ar = sx_archive
+    def __init__(self, sx, pyi_archive):
+        self.sx = sx
         self.pyi_ar = pyi_archive
 
         self.tmpdir = tempfile.TemporaryDirectory(prefix='staticx-pyi-')
@@ -109,4 +109,4 @@ class PyInstallHook:
                 continue
 
             logging.debug("Adding {} to archive".format(dep))
-            self.sx_ar.add_library(deppath, exist_ok=True)
+            self.sx.add_library(deppath, exist_ok=True)


### PR DESCRIPTION
This PR pretty substantially refactors staticx.

The original goal was to make #173 easier, by adding a single point where libraries are added.

The primary change is to add a top-level `StaticxGenerator` class which maintains the necessary state while the output is generated.