### PR TITLE
Lazily copy libraries before modifying and rework add_library()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `RPATH`/`RUNPATH`. Libraries now have `RPATH`/`RUNPATH` removed while being
   added, unless those libraries come from a PyInstalled application. ([#173])
 
+### Changed
+- Rework library-adding code to lazily copy libraries before modifying ([#192])
+
 
 ## [0.12.3] - 2021-09-04
 ### Added
@@ -250,3 +253,4 @@ Initial release
 [#179]: https://github.com/JonathonReinhart/staticx/pull/179
 [#180]: https://github.com/JonathonReinhart/staticx/pull/180
 [#185]: https://github.com/JonathonReinhart/staticx/pull/185
+[#192]: https://github.com/JonathonReinhart/staticx/pull/192


### PR DESCRIPTION
This PR was motivated by noticing this line:

https://github.com/JonathonReinhart/staticx/blob/159fba33/staticx/api.py#L177

I think this could cause some symlinks to get missed if `--strip` was passed.

I decided to just re-write this code to be safer, and also only copy libraries lazily before we modify them.


The order of operations looks to be correct:
```
INFO:root:Processing library libnss_files.so.2 (/lib/x86_64-linux-gnu/libnss_files.so.2)
INFO:root:Adding Symlink libnss_files.so.2 => libnss_files-2.31.so
INFO:root:Copying /lib/x86_64-linux-gnu/libnss_files-2.31.so to /tmp/staticx-archive-4hx7iz7r/libnss_files-2.31.so
INFO:root:Stripping library /tmp/staticx-archive-4hx7iz7r/libnss_files-2.31.so
DEBUG:root:Running ['strip', '/tmp/staticx-archive-4hx7iz7r/libnss_files-2.31.so']
INFO:root:Adding /tmp/staticx-archive-4hx7iz7r/libnss_files-2.31.so as libnss_files-2.31.so
```