### PR TITLE
Fix ldd warning about not have execution permission for libnssfix.so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fix ldd warning about libnssfix.so not being executable ([#204])
+
+
 ## [0.13.2] - 2021-10-09
 ### Added
 - Log additional diagnostic information at startup ([#199])
@@ -269,3 +274,4 @@ Initial release
 [#192]: https://github.com/JonathonReinhart/staticx/pull/192
 [#197]: https://github.com/JonathonReinhart/staticx/pull/197
 [#199]: https://github.com/JonathonReinhart/staticx/pull/199
+[#204]: https://github.com/JonathonReinhart/staticx/pull/204

--- a/staticx/hooks/glibc.py
+++ b/staticx/hooks/glibc.py
@@ -1,6 +1,7 @@
 from ..assets import copy_asset_to_tempfile
 from ..errors import InternalError
 from ..elf import open_elf, get_shobj_deps, patch_elf
+from ..utils import make_executable
 from elftools.elf.gnuversions import GNUVerNeedSection
 import logging
 
@@ -29,6 +30,9 @@ def process_glibc_prog(sx):
     # operates on the *original* executable and not the copied/modified one,
     # (see dfa201b07e) so it doesn't see changes made here.
     with nssfix:
+        # Silence "you do not have execution permission" warning from ldd
+        make_executable(nssfix.name)
+
         # TODO: Don't use sxar
         sx.sxar.add_fileobj(LIBNSSFIX, nssfix)
         for libpath in get_shobj_deps(nssfix.name):


### PR DESCRIPTION
This fixes #203

Supersedes #200