### PR TITLE
Fix bug causing crash when -l is used with a library needing to be modified by staticx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Change --debug option to appear in CLI help output
+- Change `--debug` option to appear in CLI help output
+
+### Fixed
+- Fix bug sometimes causing a crash when `-l` is used ([#217])
+
 
 ## [0.13.5] - 2021-10-26
 ### Fixed
@@ -293,3 +297,4 @@ Initial release
 [#204]: https://github.com/JonathonReinhart/staticx/pull/204
 [#208]: https://github.com/JonathonReinhart/staticx/pull/208
 [#210]: https://github.com/JonathonReinhart/staticx/pull/210
+[#217]: https://github.com/JonathonReinhart/staticx/pull/217

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -41,7 +41,7 @@ class StaticxGenerator:
         # Temporary output file (bootloader copy)
         self.tmpoutput = None
         self.tmpprog = None
-        self.tmpdir = None
+        self.tmpdir = mkdtemp(prefix='staticx-archive-')
 
         f = NamedTemporaryFile(prefix='staticx-archive-', suffix='.tar')
         self.sxar = SxArchive(fileobj=f, mode='w', compress=self.compress)
@@ -130,7 +130,6 @@ class StaticxGenerator:
 
 
         # Build the archive to be appended
-        self.tmpdir = mkdtemp(prefix='staticx-archive-')
         with self.sxar as ar:
             run_hooks(self)
 


### PR DESCRIPTION
When `-l` is used, `StaticxGenerator.add_library()` is called before `.generate()`. In this case, `.tmpdir` is `None`. If `work_on_copy()` is subsequently called because the library needs to be modified by staticx (either because `--strip` is given, or because its RPATH is about to be removed), then `.tmpdir` is used without being set.

This simply moves the `.tmpdir` creation into `StaticxGenerator.__init__`.

This isn't the best solution; you shouldn't really do a bunch of filesystem things in `__init__` -- specifically, if one of the things triggers an exception, then no cleanup will be performed (because `__exit__` will not be called). I'm not sure what the best solution is, though. Perhaps creating temp files in `__enter__`, or adding an `initialize()` API (and all of the mechanics required to ensure that it is called before `generate()` or `add_libary()`, lest we be back in this same boat.)

This bug was introduced in 57a147f0bb when `add_library()` was first used outside of `generate()`.

This fixes #216