### PR TITLE
Specify tmpdir at build

### DIFF
--- a/bootloader/util.h
+++ b/bootloader/util.h
@@ -2,5 +2,5 @@
 #define UTIL_H
 
 int remove_tree(const char *pathname);
-
+int     mkpath     (const char *dir, mode_t mode);
 #endif /* UTIL_H */

--- a/bootloader/util.h
+++ b/bootloader/util.h
@@ -3,4 +3,8 @@
 
 int remove_tree(const char *pathname);
 int     mkpath     (const char *dir, mode_t mode);
+const char * get_tmpdir(void);
+char *strtrim(char *str);
+char *get_tmp_root(void);
+void inPlaceStrTrim(char* str);
 #endif /* UTIL_H */

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -32,6 +32,9 @@ Options:
   --debug               Set loglevel to DEBUG and use a debug version of the
                         bootloader
 
+  --tmprootdir          Set tmprootdir (where the files will be unpacked
+                        default /tmp/staticx-XXXXXX)
+
   -V, --version         Show StaticX version and exit
 
 

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -33,6 +33,8 @@ def parse_args():
 
     ap.add_argument('--debug', action='store_true')
 
+    ap.add_argument('--tmprootdir', action="store", help="Set temp dir at compile time")
+
     args = ap.parse_args()
 
     if args.loglevel is None:
@@ -51,6 +53,7 @@ def main():
                 strip = args.strip,
                 compress = not args.no_compress,
                 debug = args.debug,
+                tmprootdir=args.tmprootdir
                 )
     except Error as e:
         if args.debug:


### PR DESCRIPTION
There is no way of specifying the temp dir at build time. The only way is to set env variable at run time which limits the power of the developer and also will ease the reverse engineering of the application as the whole package resides.
By having a predicteble path that can be seen (and edited) by any user it will ease privilege escalations as different libraries may be loaded at different times (just searching excuses for this parameter to exist but there are multiple scenarios).

Not the cleanest implementation but as the bootloader is compiled at staticx build time, not at program build time, it was faster to implement it this way.
