### PR TITLE
Create tempdir if it does not exist

### DIFF
--- a/bootloader/util.h
+++ b/bootloader/util.h
@@ -2,5 +2,5 @@
 #define UTIL_H
 
 int remove_tree(const char *pathname);
-
+int     mkpath     (const char *dir, mode_t mode);
 #endif /* UTIL_H */


### PR DESCRIPTION
If the _tmproot_ (TMPDIR or "/tmp") does not exist, an error will be triggered.
Recursive creating _tmproot_ if it does not exist.

It would have been nice to import libite but it would have create a new dependency
Credits for mkpath: https://github.com/troglobit/libite/blob/master/src/makepath.c#L40