### PR TITLE
Use deadsnakes action and update python versions in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: False
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches
     - run: git fetch --prune --unshallow
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: deadsnakes/action@v2.1.1
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Targetting the branch for #194, this fixes the problem mentioned in https://github.com/JonathonReinhart/staticx/pull/194#issuecomment-977538789 by using the deadsnakes action to set up python.

Also updates the version matrix to the currently supported versions of python. CI is green on this branch (https://github.com/jmsmkn/staticx/actions/runs/2344440898) but the tests fail against master as the branch is a few commits behind.

#124 
#193 