### PR TITLE
Ignore the case where a library symlink has the same basename as its target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+### Fixed
+- Fixed an issue where library symlinks with the same basename would present
+  problems ([#225])
+
 ## [0.13.6] - 2021-12-02
 ### Changed
 - Change `--debug` option to appear in CLI help output
@@ -299,3 +304,4 @@ Initial release
 [#208]: https://github.com/JonathonReinhart/staticx/pull/208
 [#210]: https://github.com/JonathonReinhart/staticx/pull/210
 [#217]: https://github.com/JonathonReinhart/staticx/pull/217
+[#225]: https://github.com/JonathonReinhart/staticx/pull/225

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -222,11 +222,13 @@ class StaticxGenerator:
         while islink(libpath):
             arcname = basename(libpath)
             libpath = get_symlink_target(libpath)
+            target = basename(libpath)
 
             # Add a symlink.
             # At this point the target probably doesn't exist, but that doesn't matter yet.
-            logging.info("Adding Symlink {} => {}".format(arcname, basename(libpath)))
-            self.sxar.add_symlink(arcname, basename(libpath))
+            logging.info("Adding Symlink {} => {}".format(arcname, target))
+            self.sxar.add_symlink(arcname, target)
+
             if arcname in self._added_libs:
                 raise InternalError("libname {} absent from _added_libs but"
                         " symlink {} present".format(libname, arcname))

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -224,6 +224,12 @@ class StaticxGenerator:
             libpath = get_symlink_target(libpath)
             target = basename(libpath)
 
+            # Skip symlinks that point to a file with the same name but in a
+            # different path. We strip path info (and keep just basenames) so
+            # this would be self-referential.
+            if arcname == target:
+                continue
+
             # Add a symlink.
             # At this point the target probably doesn't exist, but that doesn't matter yet.
             logging.info("Adding Symlink {} => {}".format(arcname, target))

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -85,6 +85,8 @@ class SxArchive:
 
     def add_symlink(self, name, target):
         """Add a symlink to the archive"""
+        if name == target:
+            raise ValueError("Refusing to add self-referential symlink")
         t = tarfile.TarInfo()
         t.type = tarfile.SYMTYPE
         t.name = name


### PR DESCRIPTION
Fixes #223 

Thanks @liujin1993 for helping to track this down.