### PR TITLE
Eliminate problematic getxxnam() calls in bootloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed an issue where library symlinks with the same basename would present
   problems ([#225])
 - Don't crash if .git/ dir is present but git is not installed ([#226])
+- Fixed potential issue where bootloader linked against glibc could result in
+  target NSS libraries being loaded and causing a cash at startup ([#228])
 
 ## [0.13.6] - 2021-12-02
 ### Changed

--- a/SConstruct
+++ b/SConstruct
@@ -13,6 +13,9 @@ base_env = Environment(
         '-Wall', '-Werror',
         '-Wmissing-prototypes', '-Wstrict-prototypes',
     ],
+    LINKFLAGS = [   # gcc is linker
+        '-Wl,--fatal-warnings',
+    ],
     BUILD_ROOT = '#scons_build',
     BUILD_DIR = '$BUILD_ROOT/$MODE',
     LIBDIR = '$BUILD_DIR/lib',

--- a/libtar/decode.c
+++ b/libtar/decode.c
@@ -12,8 +12,6 @@
 
 #include <stdio.h>
 #include <sys/param.h>
-#include <pwd.h>
-#include <grp.h>
 #include <string.h>
 #include "libtar.h"
 
@@ -37,38 +35,6 @@ th_get_pathname(const TAR *t)
 
 	snprintf(filename, sizeof(filename), "%.100s", t->th_buf.name);
 	return filename;
-}
-
-
-uid_t
-th_get_uid(const TAR *t)
-{
-	int uid;
-	struct passwd *pw;
-
-	pw = getpwnam(t->th_buf.uname);
-	if (pw != NULL)
-		return pw->pw_uid;
-
-	/* if the password entry doesn't exist */
-	sscanf(t->th_buf.uid, "%o", &uid);
-	return uid;
-}
-
-
-gid_t
-th_get_gid(const TAR *t)
-{
-	int gid;
-	struct group *gr;
-
-	gr = getgrnam(t->th_buf.gname);
-	if (gr != NULL)
-		return gr->gr_gid;
-
-	/* if the group entry doesn't exist */
-	sscanf(t->th_buf.gid, "%o", &gid);
-	return gid;
 }
 
 

--- a/libtar/extract.c
+++ b/libtar/extract.c
@@ -17,7 +17,6 @@
 #include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <errno.h>
-#include <utime.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <unistd.h>
@@ -44,62 +43,6 @@ static int mkdirs_for(const char *filename)
 
 	free(fndup);
 	return rc;
-}
-
-static int
-tar_set_file_perms(TAR *t, const char *realname)
-{
-	mode_t mode;
-	uid_t uid;
-	gid_t gid;
-	struct utimbuf ut;
-	const char *filename;
-
-	filename = (realname ? realname : th_get_pathname(t));
-	mode = th_get_mode(t);
-	uid = th_get_uid(t);
-	gid = th_get_gid(t);
-	ut.modtime = ut.actime = th_get_mtime(t);
-
-	/* change owner/group */
-	if (geteuid() == 0)
-#ifdef HAVE_LCHOWN
-		if (lchown(filename, uid, gid) == -1)
-		{
-# ifdef DEBUG
-			fprintf(stderr, "lchown(\"%s\", %d, %d): %s\n",
-				filename, uid, gid, strerror(errno));
-# endif
-#else /* ! HAVE_LCHOWN */
-		if (!TH_ISSYM(t) && chown(filename, uid, gid) == -1)
-		{
-# ifdef DEBUG
-			fprintf(stderr, "chown(\"%s\", %d, %d): %s\n",
-				filename, uid, gid, strerror(errno));
-# endif
-#endif /* HAVE_LCHOWN */
-			return -1;
-		}
-
-	/* change access/modification time */
-	if (!TH_ISSYM(t) && utime(filename, &ut) == -1)
-	{
-#ifdef DEBUG
-		perror("utime()");
-#endif
-		return -1;
-	}
-
-	/* change permissions */
-	if (!TH_ISSYM(t) && chmod(filename, mode) == -1)
-	{
-#ifdef DEBUG
-		perror("chmod()");
-#endif
-		return -1;
-	}
-
-	return 0;
 }
 
 
@@ -145,9 +88,10 @@ tar_extract_file(TAR *t, const char *realname)
 	if (i != 0)
 		return i;
 
-	i = tar_set_file_perms(t, realname);
-	if (i != 0)
-		return i;
+	/**
+	 * staticx: removed tar_set_file_perms() here as we set the only
+	 * perms we care about in tar_extract_regfile().
+	 */
 
 	pathname_len = strlen(th_get_pathname(t)) + 1;
 	realname_len = strlen(realname) + 1;
@@ -199,8 +143,6 @@ tar_extract_regfile(TAR *t, const char *realname)
 	mode = th_get_mode(t);
 	size = th_get_size(t);
 
-	(void)mode;
-
 	if (mkdirs_for(filename) == -1)
 		goto out;
 
@@ -222,9 +164,7 @@ tar_extract_regfile(TAR *t, const char *realname)
 	}
 
 	/* NOTE: We do not change owner, as that would require root */
-#if 0
 
-	/* make sure the mode isn't inheritted from a file we're overwriting */
 	if (fchmod(fdout, mode & 07777) == -1)
 	{
 #ifdef DEBUG
@@ -232,7 +172,6 @@ tar_extract_regfile(TAR *t, const char *realname)
 #endif
 		goto out;
 	}
-#endif
 
 	/* extract the file */
 

--- a/libtar/extract.c
+++ b/libtar/extract.c
@@ -177,8 +177,6 @@ tar_extract_regfile(TAR *t, const char *realname)
 {
 	mode_t mode;
 	size_t size;
-	uid_t uid;
-	gid_t gid;
 	int fdout = -1;
 	const char *filename;
 	size_t to_read;
@@ -200,19 +198,15 @@ tar_extract_regfile(TAR *t, const char *realname)
 	filename = (realname ? realname : th_get_pathname(t));
 	mode = th_get_mode(t);
 	size = th_get_size(t);
-	uid = th_get_uid(t);
-	gid = th_get_gid(t);
 
 	(void)mode;
-	(void)uid;
-	(void)gid;
 
 	if (mkdirs_for(filename) == -1)
 		goto out;
 
 #ifdef DEBUG
-	printf("  ==> extracting: %s (mode %04o, uid %d, gid %d, %zd bytes)\n",
-	       filename, mode, uid, gid, size);
+	printf("  ==> extracting: %s (mode %04o, %zd bytes)\n",
+	       filename, mode, size);
 #endif
 	fdout = open(filename, O_WRONLY | O_CREAT | O_TRUNC
 #ifdef O_BINARY
@@ -227,15 +221,8 @@ tar_extract_regfile(TAR *t, const char *realname)
 		goto out;
 	}
 
+	/* NOTE: We do not change owner, as that would require root */
 #if 0
-	/* change the owner.  (will only work if run as root) */
-	if (fchown(fdout, uid, gid) == -1 && errno != EPERM)
-	{
-#ifdef DEBUG
-		perror("fchown()");
-#endif
-		goto out;
-	}
 
 	/* make sure the mode isn't inheritted from a file we're overwriting */
 	if (fchmod(fdout, mode & 07777) == -1)

--- a/libtar/handle.c
+++ b/libtar/handle.c
@@ -19,7 +19,7 @@
 
 
 TAR *
-tar_new(void *context, tartype_t *type, int options)
+tar_new(void *context, const tartype_t *type, int options)
 {
 	TAR *t;
 

--- a/libtar/libtar.h
+++ b/libtar/libtar.h
@@ -145,8 +145,6 @@ int th_read(TAR *t);
                             : (t)->th_buf.linkname)
 const char *th_get_pathname(const TAR *t);
 mode_t th_get_mode(const TAR *t);
-uid_t th_get_uid(const TAR *t);
-gid_t th_get_gid(const TAR *t);
 
 
 /***** extract.c ***********************************************************/

--- a/libtar/libtar.h
+++ b/libtar/libtar.h
@@ -73,7 +73,7 @@ tartype_t;
 
 typedef struct
 {
-	tartype_t *type;
+	const tartype_t *type;
 	void *context;
 	int options;
 	struct tar_header th_buf;
@@ -94,7 +94,7 @@ TAR;
 
 
 /* make a tarfile handle */
-TAR *tar_new(void *context, tartype_t *type, int options);
+TAR *tar_new(void *context, const tartype_t *type, int options);
 
 /* close tarfile handle */
 int tar_close(TAR *t);

--- a/libtar/output.c
+++ b/libtar/output.c
@@ -11,8 +11,6 @@
 */
 
 #include <stdio.h>
-#include <pwd.h>
-#include <grp.h>
 #include <time.h>
 #include <limits.h>
 #include <sys/param.h>
@@ -30,12 +28,6 @@ void
 th_print_long_ls(const TAR *t, FILE *f)
 {
 	char modestring[12];
-	struct passwd *pw;
-	struct group *gr;
-	uid_t uid;
-	gid_t gid;
-	char username[_POSIX_LOGIN_NAME_MAX];
-	char groupname[_POSIX_LOGIN_NAME_MAX];
 	time_t mtime;
 	struct tm *mtm;
 
@@ -48,22 +40,8 @@ th_print_long_ls(const TAR *t, FILE *f)
 	};
 #endif
 
-	uid = th_get_uid(t);
-	pw = getpwuid(uid);
-	if (pw == NULL)
-		snprintf(username, sizeof(username), "%d", uid);
-	else
-		strlcpy(username, pw->pw_name, sizeof(username));
-
-	gid = th_get_gid(t);
-	gr = getgrgid(gid);
-	if (gr == NULL)
-		snprintf(groupname, sizeof(groupname), "%d", gid);
-	else
-		strlcpy(groupname, gr->gr_name, sizeof(groupname));
-
 	strmode(th_get_mode(t), modestring);
-	fprintf(f, "%.10s %-8.8s %-8.8s ", modestring, username, groupname);
+	fprintf(f, "%.10s %-8.8s %-8.8s ", modestring, t->th_buf.uname, t->th_buf.gname);
 
 	if (TH_ISCHR(t) || TH_ISBLK(t))
 		fprintf(f, " %3d, %3d ", th_get_devmajor(t), th_get_devminor(t));


### PR DESCRIPTION
glibc warns us that we shouldn't call functions like `getpwnam()` from a statically-linked application:
```
decode.c:(.text+0x88): warning: Using 'getpwnam' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

The reason is that it will actually dlopen() the libnss libraries, and then possibly explode.

This PR eliminates the `getpwnam`/`getgrnam` calls from `libtar`, and adds a linker flag to make sure it doesn't happen again.

Note that libtar keeps losing more and more fingers, but that's okay because we don't really need much of its functionality. See also #229 because this is annoying.

Fixes #227.