### PR TITLE
fix: update to support new pyinstaller 5.10 syntax

### DIFF
--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -6,6 +6,7 @@ from ..elf import get_shobj_deps, is_dynamic, LddError
 from ..errors import Error, UnsupportedRpathError, UnsupportedRunpathError
 from ..utils import make_executable, mkdirs_for
 
+
 def process_pyinstaller_archive(sx):
     # See utils/cliutils/archive_viewer.py
 
@@ -15,6 +16,15 @@ def process_pyinstaller_archive(sx):
     except ImportError:
         return
 
+    pre_510 = False
+    try:
+        from PyInstaller.archive.readers import CTOCReader
+
+        # if CTocReader is available, we're running PyInstaller before 5.10 or later
+        pre_510 = True
+    except ImportError:
+        pass
+
     # Attempt to open the program as PyInstaller archive
     try:
         pyi_ar = CArchiveReader(sx.orig_prog)
@@ -23,25 +33,25 @@ def process_pyinstaller_archive(sx):
         return
     logging.info("Opened PyInstaller archive!")
 
-    with PyInstallHook(sx, pyi_ar) as h:
+    with PyInstallHook(sx, pyi_ar, pre_510) as h:
         h.process()
 
 
-
 class PyInstallHook:
-    def __init__(self, sx, pyi_archive):
+    def __init__(self, sx, pyi_archive, pre_510):
         self.sx = sx
         self.pyi_ar = pyi_archive
+        # if this pyinstaller archive is from before 5.10, we need to use a different method
+        # to extract the binaries
+        self.pre_510 = pre_510
 
-        self.tmpdir = tempfile.TemporaryDirectory(prefix='staticx-pyi-')
-
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="staticx-pyi-")
 
     def __enter__(self):
         return self
 
     def __exit__(self, *exc_info):
         self.tmpdir.cleanup()
-
 
     def process(self):
         binaries = self._extract_binaries()
@@ -56,24 +66,30 @@ class PyInstallHook:
         for binary in binaries:
             self._add_required_deps(binary)
 
-
     def _extract_binaries(self):
         result = []
+        if self.pre_510:
+            toc_data = self.pyi_ar.toc.data
+        else:
+            toc_data = [entry + (name,) for name, entry in self.pyi_ar.toc.items()]
 
-        for n, item in enumerate(self.pyi_ar.toc.data):
+        for n, item in enumerate(toc_data):
             (dpos, dlen, ulen, flag, typcd, name) = item
 
             # Only process binary files
             # See xformdict in PyInstaller.building.api.PKG
-            if typcd != 'b':
+            if typcd != "b":
                 continue
 
             # Extract it to a temporary location
-            _, data = self.pyi_ar.extract(n)
+            if self.pre_510:
+                _, data = self.pyi_ar.extract(n)
+            else:
+                data = self.pyi_ar.extract(name)
             tmppath = os.path.join(self.tmpdir.name, name)
             logging.debug("Extracting to {}".format(tmppath))
             mkdirs_for(tmppath)
-            with open(tmppath, 'wb') as f:
+            with open(tmppath, "wb") as f:
                 f.write(data)
 
             # Silence "you do not have execution permission" warning from ldd
@@ -123,13 +139,17 @@ class PyInstallHook:
             logging.warning(e)
             return
 
-
         # Add any missing libraries to our archive
         for deppath in deps:
             dep = os.path.basename(deppath)
 
-            if self.pyi_ar.toc.find(dep) != -1:
-                logging.debug("{} already in pyinstaller archive".format(dep))
-                continue
+            if self.pre_510:
+                if self.pyi_ar.toc.find(dep) != -1:
+                    logging.debug("{} already in pyinstaller archive".format(dep))
+                    continue
+            else:
+                if dep in self.pyi_ar.toc:
+                    logging.debug("{} already in pyinstaller archive".format(dep))
+                    continue
 
             self.sx.add_library(deppath, exist_ok=True)


### PR DESCRIPTION
https://github.com/JonathonReinhart/staticx/issues/235 https://github.com/pyinstaller/pyinstaller/issues/7560 
This adds support for the new pyinstaller > 5.10 syntax for pyi_archive tocs.

@JonathonReinhart I tested this locally and it seems to be working and the pytests pass, but I'm not sure how I would add additional unit testing for this code. 