### PR TITLE
Use Python 3.7 language features

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def get_dynamic_version():
     build_num = os.getenv('TRAVIS_BUILD_NUMBER')
     build_tag = os.getenv('TRAVIS_TAG')
     if (not build_tag) and (build_num != None):
-        return '{}.{}'.format(staticx.version.BASE_VERSION, build_num)
+        return f'{staticx.version.BASE_VERSION}.{build_num}'
 
     return staticx.version.__version__
 
@@ -40,7 +40,7 @@ class build_bootloader(Command):
         args = [
             'scons',
             '-Q',       # Quiet output (except for build status)
-            'STATICX_VERSION={}'.format(get_dynamic_version()),
+            f'STATICX_VERSION={get_dynamic_version()}',
         ]
         check_call(args)
 
@@ -95,7 +95,7 @@ def get_platform():
     # Check compatibility
     if osname != "linux":
         # Right now staticx only supports Linux
-        raise UnsupportedPlatformError("OS {!r} unsupported by staticx".format(osname))
+        raise UnsupportedPlatformError(f"OS {osname!r} unsupported by staticx")
 
     # Adjust machine if necessary
     #
@@ -109,7 +109,7 @@ def get_platform():
     if machine == "x86_64" and sys.maxsize == 0x7fffffff:
         machine = "i686"
 
-    return 'manylinux1_{}'.format(machine)
+    return f'manylinux1_{machine}'
 
 ################################################################################
 

--- a/site_scons/site_tools/nsswitchconf.py
+++ b/site_scons/site_tools/nsswitchconf.py
@@ -15,11 +15,12 @@ def _gen_nsswitch_conf_h(target, source, env):
     conf = read_nsswitch_conf(source[0].get_path())
     with open(target[0].get_path(), 'w') as tgtf:
         for dbname, svcs in conf:
-            tgtf.write('NSSWITCH_CONF("{}", "{}")\n'.format(dbname, ' '.join(svcs)))
+            svc_line = " ".join(svcs)
+            tgtf.write(f'NSSWITCH_CONF("{dbname}", "{svc_line}")\n')
 
 
 def _strfunc(target, source, env):
-    return "Creating '%s'" % target[0]
+    return f"Creating '{target[0]}'"
 
 def NsswitchConfH(env, target, source):
     return env.Command(

--- a/site_scons/site_tools/stubgen.py
+++ b/site_scons/site_tools/stubgen.py
@@ -20,8 +20,8 @@ def ShlibStubGen(env, target, symbols):
     lines = ['// Auto-generated stub']
     for sym in symbols:
         lines += [
-            'void {}(void);'.format(sym),       # for strict prototypes
-            'void {}(void) {{}}'.format(sym),
+            f'void {sym}(void);',       # for strict prototypes
+            f'void {sym}(void) {{}}',
             '',
         ]
 

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -29,7 +29,7 @@ def parse_args():
     ap.add_argument('-V', '--version', action='version',
             version = '%(prog)s ' + __version__)
     ap.add_argument('--loglevel', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-            help = 'Set the logging level (default: {})'.format(DEFAULT_LOGLEVEL))
+            help = f'Set the logging level (default: {DEFAULT_LOGLEVEL})')
 
     ap.add_argument('--debug', action='store_true')
 

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -92,7 +92,7 @@ class StaticxGenerator:
                 args = [bootloader],
                 env = dict(STATICX_BOOTLOADER_IDENTIFY='1'),
                 stderr = subprocess.PIPE,
-                universal_newlines = True,  # TODO: 'text' in Python 3.7
+                text = True,
                 )
         r.check_returncode()
         lines = (line.split(':', 1)[1].strip() for line in r.stderr.splitlines())

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -84,8 +84,8 @@ class StaticxGenerator:
         bldr_mach = get_machine(bootloader)
         prog_mach = get_machine(self.orig_prog)
         if bldr_mach != prog_mach:
-            raise FormatMismatchError("Bootloader machine ({}) doesn't match "
-                    "program machine ({})".format(bldr_mach, prog_mach))
+            raise FormatMismatchError(
+                f"Bootloader machine ({bldr_mach}) doesn't match program machine ({prog_mach})")
 
         # Run the bootloader for identification
         r = subprocess.run(
@@ -125,7 +125,7 @@ class StaticxGenerator:
         if self.strip:
             # TODO: Now that we have ship separate debug/release bootloaders
             # do we ever want and need to do this at staticx-time?
-            logging.info("Stripping bootloader {}".format(self.tmpoutput))
+            logging.info(f"Stripping bootloader {self.tmpoutput}")
             strip_elf(self.tmpoutput)
 
 
@@ -165,7 +165,7 @@ class StaticxGenerator:
                 return
             raise LibExistsError(libname)
 
-        logging.info("Processing library {} ({})".format(libname, libpath))
+        logging.info(f"Processing library {libname} ({libpath})")
 
         # Handle symlinks
         libpath = self._handle_lib_symlinks(libpath)
@@ -178,7 +178,7 @@ class StaticxGenerator:
             nonlocal libpath
 
             tmplib = os.path.join(self.tmpdir, basename(libpath))
-            logging.info("Copying {} to {}".format(libpath, tmplib))
+            logging.info(f"Copying {libpath} to {tmplib}")
             shutil.copy(libpath, tmplib)
             libpath = tmplib
 
@@ -192,23 +192,23 @@ class StaticxGenerator:
         except (UnsupportedRpathError, UnsupportedRunpathError):
             # Fix it by removing
             work_on_copy()
-            logging.info("Removing RPATH/RUNPATH from library {}".format(libpath))
+            logging.info(f"Removing RPATH/RUNPATH from library {libpath}")
             remove_rpath(libpath)
 
         # Strip the library
         if self.strip:
             work_on_copy()
-            logging.info("Stripping library {}".format(libpath))
+            logging.info(f"Stripping library {libpath}")
             strip_elf(libpath)
 
 
         # Finally, add it to the archive.
         arcname = basename(libpath)
-        logging.info("Adding {} as {}".format(libpath, arcname))
+        logging.info(f"Adding {libpath} as {arcname}")
         self.sxar.add_file(libpath, arcname=arcname)
         if arcname in self._added_libs:
-            raise InternalError("libname {} absent from _added_libs but"
-                    " library {} present".format(libname, arcname))
+            raise InternalError(
+                f"libname {libname} absent from _added_libs but library {arcname} present")
         self._added_libs[arcname] = libpath
 
 
@@ -232,12 +232,12 @@ class StaticxGenerator:
 
             # Add a symlink.
             # At this point the target probably doesn't exist, but that doesn't matter yet.
-            logging.info("Adding Symlink {} => {}".format(arcname, target))
+            logging.info(f"Adding Symlink {arcname} => {target}")
             self.sxar.add_symlink(arcname, target)
 
             if arcname in self._added_libs:
-                raise InternalError("libname {} absent from _added_libs but"
-                        " symlink {} present".format(libname, arcname))
+                raise InternalError(
+                    f"libname {libname} absent from _added_libs but symlink {arcname} present")
             self._added_libs[arcname] = None    # Don't care about real target for symlinks
 
         return libpath
@@ -282,7 +282,7 @@ class StaticxGenerator:
 
         # Strip user prog before modifying it
         if self.strip:
-            logging.info("Stripping prog {}".format(self.tmpprog))
+            logging.info(f"Stripping prog {self.tmpprog}")
             strip_elf(self.tmpprog)
 
         # Set long dummy INTERP and RPATH in the executable to allow plenty of space
@@ -305,15 +305,15 @@ def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
     debug: Run in debug mode (use debug bootloader)
     """
 
-    logging.info("Running StaticX version {}".format(__version__))
+    logging.info(f"Running StaticX version {__version__}")
     verify_tools()
     logging.debug("Arguments:")
-    logging.debug("  prog:      {!r}".format(prog))
-    logging.debug("  output:    {!r}".format(output))
-    logging.debug("  libs:      {!r}".format(libs))
-    logging.debug("  strip:     {!r}".format(strip))
-    logging.debug("  compress:  {!r}".format(compress))
-    logging.debug("  debug:     {!r}".format(debug))
+    logging.debug(f"  prog:      {prog!r}")
+    logging.debug(f"  output:    {output!r}")
+    logging.debug(f"  libs:      {libs!r}")
+    logging.debug(f"  strip:     {strip!r}")
+    logging.debug(f"  compress:  {compress!r}")
+    logging.debug(f"  debug:     {debug!r}")
 
     gen = StaticxGenerator(
             prog=prog,

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -27,7 +27,7 @@ def get_xz_filters():
     # Get a BCJ filter for the current architecture
     bcj_filter, bcj_filter_name = get_bcj_filter()
     if bcj_filter:
-        logging.info("Using XZ BCJ filter {}".format(bcj_filter_name))
+        logging.info(f"Using XZ BCJ filter {bcj_filter_name}")
         filters.append(dict(id=bcj_filter))
 
     # The last filter in the chain must be a compression filter.
@@ -95,7 +95,7 @@ class SxArchive:
         self.tar.addfile(t)
 
     def add_fileobj(self, name, fileobj):
-        logging.info("Adding {}".format(name))
+        logging.info(f"Adding {name}")
         tarinfo = self.tar.gettarinfo(arcname=name, fileobj=fileobj)
         tarinfo.mode = make_mode_executable(tarinfo.mode)
         self.tar.addfile(tarinfo, fileobj)
@@ -117,7 +117,7 @@ class SxArchive:
             tarinfo.mode = make_mode_executable(tarinfo.mode)
             return tarinfo
 
-        logging.info("Adding {} as {}".format(path, name))
+        logging.info(f"Adding {path} as {name}")
         self.tar.add(path, arcname=name, filter=make_exec)
 
         # Store a link to the program so the bootloader knows what to execute

--- a/staticx/assets.py
+++ b/staticx/assets.py
@@ -7,7 +7,7 @@ def locate_asset(name, debug):
     try:
         return pkg_resources.resource_stream(__name__, path)
     except FileNotFoundError:
-        raise KeyError("Asset not found: {!r} (mode={!r})".format(name, mode))
+        raise KeyError(f"Asset not found: {name!r} (mode={mode!r})")
 
 
 def copy_asset_to_tempfile(assetname, debug, **kwargs):

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -47,18 +47,11 @@ class ExternTool:
         try:
             r = subprocess.run(
                 args = args,
-
-                #capture_output = True,         # TODO: Python 3.7
-                stdout = subprocess.PIPE,
-                stderr = subprocess.PIPE,
-
+                capture_output = True,
+                encoding = self.encoding,
                 **kw)
         except FileNotFoundError:
             raise MissingToolError(self.cmd, self.os_pkg)
-
-        # TODO: Python 3.6: Simply set encoding in run() call
-        r.stdout = r.stdout.decode(self.encoding)
-        r.stderr = r.stderr.decode(self.encoding)
 
         # Hide ignored lines from stderr
         if not _internal:

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -5,7 +5,6 @@ import locale
 import logging
 import errno
 import os
-from pprint import pformat
 
 import elftools
 from elftools.elf.elffile import ELFFile
@@ -18,7 +17,7 @@ from .utils import coerce_sequence, single, which_exec
 
 def verify_tools():
     logging.info("Libraries:")
-    logging.info("  elftools: {}".format(elftools.__version__))
+    logging.info(f"  elftools: {elftools.__version__}")
 
     extern_tools_verify()
 
@@ -75,7 +74,7 @@ class ExternTool:
         rc, stdout = self.run(*args, **kw)
 
         if rc != 0:
-            raise ToolError(self.cmd, '{} returned {}'.format(self.cmd, rc))
+            raise ToolError(self.cmd, f'{self.cmd} returned {rc}')
 
         return stdout
 
@@ -83,7 +82,7 @@ class ExternTool:
         rc, output = self.run('--version', _internal=True)
         if rc == 0:
             return output.splitlines()[0]
-        return "??? (exited {})".format(rc)
+        return f"??? (exited {rc})"
 
     def which(self):
         return which_exec(self.cmd)
@@ -106,7 +105,7 @@ all_tools = (tool_ldd, tool_objcopy, tool_strip, tool_patchelf)
 def extern_tools_verify():
     logging.debug("External tools:")
     for t in all_tools:
-        logging.info("  {}: {}: {}".format(t.cmd, t.which(), t.get_version()))
+        logging.info(f"  {t.cmd}: {t.which()}: {t.get_version()}")
 
 
 class LddError(ToolError):
@@ -192,7 +191,7 @@ def get_shobj_deps(path, libpath=None):
         # produced by musl-libc
         #
         # We simply raise a specific exception and let the caller deal with it.
-        message = "Unexpected ldd error ({}):\n{}".format(rc, output.strip('\n'))
+        message = f"Unexpected ldd error ({rc}):\n" + output.strip('\n')
         if "invalid ELF header" in output:
             message += "\nHint: try setting STATICX_LDD to the appropriate ldd for this executable"
         raise LddError(message)
@@ -203,7 +202,7 @@ def get_shobj_deps(path, libpath=None):
 
 def elf_add_section(elfpath, secname, secfilename):
     tool_objcopy.run_check(
-        '--add-section', '{}={}'.format(secname, secfilename),
+        '--add-section', f'{secname}={secfilename}',
         elfpath)
 
 
@@ -212,7 +211,7 @@ def elf_dump_section(elfpath, secname, outpath):
     tool_objcopy.run_check(
         '-O', 'binary',
         '--only-section', secname,
-        '--set-section-flags', '{}={}'.format(secname, 'alloc'),
+        '--set-section-flags', f"{secname}=alloc",
         elfpath, outpath)
 
 
@@ -257,7 +256,7 @@ def strip_elf(path):
 class StaticELFError(Error):
     """Dynamic operation requested on static executable"""
     def __init__(self, path):
-        message = "{} is a static ELF file".format(path)
+        message = f"{path} is a static ELF file"
         super().__init__(message)
 
 
@@ -291,8 +290,8 @@ class ELFFileX(ELFFile):
             except AttributeError:
                 continue
 
-        raise InvalidInputError("{}: not a dynamic executable "
-                                "(no interp segment)".format(self.__path))
+        raise InvalidInputError(
+            f"{self.__path}: not a dynamic executable (no interp segment)")
 
 
     def get_dynamic_segment(self):
@@ -325,7 +324,7 @@ def open_elf(path, mode='rb'):
     try:
         return ELFFileX.open(path, mode)
     except ELFError as e:
-        raise InvalidInputError("{}: Invalid ELF image: {}".format(path, e))
+        raise InvalidInputError(f"{path}: Invalid ELF image: {e}")
 
 
 def get_machine(path):

--- a/staticx/errors.py
+++ b/staticx/errors.py
@@ -10,14 +10,13 @@ class InternalError(Error):
 class ToolError(Error):
     """An external tool indicated an error"""
     def __init__(self, program, message=None):
-        super().__init__(message or "'{}' failed".format(program))
+        super().__init__(message or f"'{program}' failed")
         self.program = program
 
 class MissingToolError(Error):
     """A required external tool is missing"""
     def __init__(self, program, package):
-        super().__init__("Couldn't find '{}'. Is '{}' installed?".format(
-            program, package))
+        super().__init__(f"Couldn't find '{program}'. Is '{package}' installed?")
         self.program = program
         self.package = package
 
@@ -34,9 +33,10 @@ class UnsupportedDynTagError(InvalidInputError):
     def __init__(self, libpath, value):
         self.libpath = libpath
         self.value = value
-        super().__init__("{} uses unsupported {} ({!r}).\n"
+        super().__init__(
+                f"{libpath} uses unsupported {self.tag} ({value!r}).\n"
                 "See https://github.com/JonathonReinhart/staticx/issues/188"
-                .format(libpath, self.tag, value))
+                )
 
 class UnsupportedRpathError(UnsupportedDynTagError):
     tag = 'DT_RPATH'
@@ -57,7 +57,7 @@ class LibExistsError(ArchiveError):
     """Given library already exists in archive"""
     def __init__(self, lib):
         super().__init__(
-                "Library '{}' already exists in archive".format(lib))
+                f"Library '{lib}' already exists in archive")
         self.lib = lib
 
 
@@ -65,5 +65,5 @@ class DirectoryExistsError(Error):
     """A given directory already exists"""
     def __init__(self, path):
         super().__init__(
-                "{}: is a directory".format(path))
+                f"{path}: is a directory")
         self.path = path

--- a/staticx/extract.py
+++ b/staticx/extract.py
@@ -15,8 +15,7 @@ def open_archive(archive):
 
     size = os.stat(f.name).st_size
     if size == 0:
-        raise ArchiveError("{} does not appear to contain a staticx archive section"
-                .format(archive))
+        raise ArchiveError(f"{archive} does not appear to contain a staticx archive section")
     return tarfile.open(fileobj=f, mode='r', format=tarfile.GNU_FORMAT)
 
 

--- a/staticx/hooks/glibc.py
+++ b/staticx/hooks/glibc.py
@@ -49,7 +49,7 @@ def is_linked_against_glibc(prog):
                 continue
             for vernaux in vernaux_iter:
                 if vernaux.name.startswith('GLIBC_'):
-                    logging.debug("Program linked with GLIBC: Found {} {}".format(
-                        verneed.name, vernaux.name))
+                    logging.debug(
+                        f"Program linked with GLIBC: Found {verneed.name} {vernaux.name}")
                     return True
     return False

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -36,7 +36,7 @@ def process_pyinstaller_archive(sx):
     # We do this after opening the archive to avoid failing for non-pyinstalled
     # input files.
     if pyi_version[:2] in ((4, 1), (4, 2)):
-        msg = "PyInstaller v{} is unsupported\n".format(PyInstaller.__version__)
+        msg = f"PyInstaller v{PyInstaller.__version__} is unsupported\n"
         msg += "(See https://github.com/JonathonReinhart/staticx/issues/170)"
         raise Error(msg)
 
@@ -89,7 +89,7 @@ class PyInstallHook:
             # Extract it to a temporary location
             data = self.pyi_ar.extract(name)
             tmppath = os.path.join(self.tmpdir.name, name)
-            logging.debug("Extracting to {}".format(tmppath))
+            logging.debug(f"Extracting to {tmppath}")
             mkdirs_for(tmppath)
             with open(tmppath, "wb") as f:
                 f.write(data)
@@ -122,7 +122,7 @@ class PyInstallHook:
             msg += "One or more libraries included in the PyInstaller"
             msg += " archive uses unsupported RPATH/RUNPATH tags:\n\n"
             for e in errors:
-                msg += "  {}: {}={!r}\n".format(e.libpath, e.tag, e.value)
+                msg += f"  {e.libpath}: {e.tag}={e.value!r}\n"
             msg += "\nSee https://github.com/JonathonReinhart/staticx/issues/188"
             raise Error(msg)
 
@@ -146,7 +146,7 @@ class PyInstallHook:
             dep = os.path.basename(deppath)
 
             if dep in self.pyi_ar.toc:
-                logging.debug("{} already in pyinstaller archive".format(dep))
+                logging.debug(f"{dep} already in pyinstaller archive")
                 continue
 
             self.sx.add_library(deppath, exist_ok=True)

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -48,13 +48,13 @@ def get_version():
             if commits == 0 and not rev.endswith('dirty'):
                 return BASE_VERSION
 
-            return '{}+{}-{}'.format(BASE_VERSION, commits, rev)
+            return f'{BASE_VERSION}+{commits}-{rev}'
 
 
     # Git archive
     # If this was produced via `git archive`, we'll use the version it provides
     if not git_archive_rev.startswith('$'):
-        return '{}+g{}'.format(BASE_VERSION, git_archive_rev)
+        return f'{BASE_VERSION}+g{git_archive_rev}'
 
 
     # Package resource

--- a/test/pyinstall/app.py
+++ b/test/pyinstall/app.py
@@ -7,7 +7,5 @@ def get_resource_dir():
     default = os.path.dirname(os.path.abspath(__file__))
     return getattr(sys, '_MEIPASS', default)
     
-print("Hello {}! Resource dir: {}".format(
-    pwd.getpwuid(os.getuid()).pw_name,
-    get_resource_dir()),
-)
+print(f"Hello {pwd.getpwuid(os.getuid()).pw_name}!")
+print(f"Resource dir: {get_resource_dir()}")


### PR DESCRIPTION
1. Where appropriate, convert to [f-strings](https://peps.python.org/pep-0498/). This was accomplished using `flynt` (https://github.com/ikamensh/flynt) with manual review and a few changes.
2. Take advantage of the new `subprocess.run()` arguments: `text`/`encoding` and `capture_output`.

Closes #246

Reference: https://github.com/JonathonReinhart/scuba/pull/206