### PR TITLE
Fix broken nssfix build on newer glibc

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,12 +7,26 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-22.04  # TODO: would be nice to matrix this w/ 20.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # It's undocumented, but matrix variable arrays can be maps, too!
+        # https://stackoverflow.com/a/68940067/119527
+        os:
+          - version: "ubuntu-20.04"
+            native-python: "3.8"
+          - version: "ubuntu-22.04"
+            native-python: "3.10"
+        python-version:
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
       fail-fast: False
+
+    name: "${{matrix.os.version}}: Python ${{matrix.python-version}}"
+
+    runs-on: ${{ matrix.os.version }}
 
     steps:
     - uses: actions/checkout@v3
@@ -25,7 +39,7 @@ jobs:
     # with StaticX. See #224.
     - name: Set up Python ${{ matrix.python-version }}
       uses: deadsnakes/action@v3.0.1
-      if: "(matrix.python-version != '3.10')"  # Already installed in ubuntu-22.04
+      if: "(matrix.python-version != matrix.os.native-python)"  # Already installed
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04  # See #245
+    runs-on: ubuntu-22.04  # TODO: would be nice to matrix this w/ 20.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
@@ -25,7 +25,7 @@ jobs:
     # with StaticX. See #224.
     - name: Set up Python ${{ matrix.python-version }}
       uses: deadsnakes/action@v3.0.1
-      if: "(matrix.python-version != '3.8')"  # Already installed in ubuntu-20.04
+      if: "(matrix.python-version != '3.10')"  # Already installed in ubuntu-22.04
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Fixed issue causing libnssfix link failure when building on GLIBC 2.34 ([#255])
+
 ### Removed
 - Dropped support for Python 3.5 and 3.6 ([#247])
 
@@ -334,3 +337,4 @@ Initial release
 [#237]: https://github.com/JonathonReinhart/staticx/pull/237
 [#238]: https://github.com/JonathonReinhart/staticx/pull/238
 [#247]: https://github.com/JonathonReinhart/staticx/pull/247
+[#255]: https://github.com/JonathonReinhart/staticx/pull/255

--- a/SConstruct
+++ b/SConstruct
@@ -66,6 +66,18 @@ conf = base_env.Configure(custom_tests=custom_tests)
 # Does our default libc have NSS?
 conf.env["HAS_NSS"] = conf.CheckNSS()
 
+# Starting in GLIBC 2.34, some NSS modules (files, dns) can be built-in to
+# libc.so. Determine which ones are builtin. See #245.
+conf.env["NSS_MODS_BUILTIN"] = []
+if conf.env["HAS_NSS"]:
+    maybe_builtin_nss_modules = ["files", "dns"]
+    for mod in maybe_builtin_nss_modules:
+        libname = "libnss_" + mod
+        # It the library doesn't exist, assume it is built-in.
+        if not conf.BasicCheckLib(libname):
+            conf.env.Append(NSS_MODS_BUILTIN=libname)
+    print("Builtin NSS modules:", conf.env["NSS_MODS_BUILTIN"])
+
 base_env = conf.Finish()
 
 ################################################################################

--- a/SConstruct
+++ b/SConstruct
@@ -59,10 +59,14 @@ def BuildSubdir(env, dirname):
 base_env.AddMethod(BuildSubdir)
 
 
+###########
+# Configure
 conf = base_env.Configure(custom_tests=custom_tests)
-has_nss = conf.CheckNSS()
-conf.Finish()
 
+# Does our default libc have NSS?
+conf.env["HAS_NSS"] = conf.CheckNSS()
+
+base_env = conf.Finish()
 
 ################################################################################
 # Bootloader
@@ -79,7 +83,7 @@ for env in bootloader_env.ModeEnvs():
 
 ################################################################################
 # nssfix
-if has_nss:
+if env['HAS_NSS']:
     for env in base_env.ModeEnvs():
         env.InstallAs('#staticx/assets/$MODE/libnssfix.so', env.BuildSubdir('libnssfix'))
 else:

--- a/libnssfix/SConscript
+++ b/libnssfix/SConscript
@@ -22,6 +22,16 @@ env.NsswitchConfH(
     source = nsswitch_conf,
 )
 
+
+# Link against the configured NSS module libraries.
+# These aren't needed directly for the library itself, but this ensures
+# that they will be available for nss at runtime (via dlopen), and
+# allows their paths to be easily discovered via ldd(1).
+nss_libs = set(env.GetNsswitchLibs(nsswitch_conf))
+
+# Exclude those already built-in to glibc.
+nss_libs -= set(env["NSS_MODS_BUILTIN"])
+
 # Build libnssfix.so
 libnssfix = env.SharedLibrary(
     target = 'nssfix',
@@ -50,12 +60,7 @@ libnssfix = env.SharedLibrary(
     ],
     LIBS = [
         libc_stub,
-
-        # These aren't needed directly for the library itself, but this ensures
-        # that they will be available for nss at runtime (via dlopen), and
-        # allows their paths to be easily discovered via ldd(1).
-        env.GetNsswitchLibs(nsswitch_conf),
-    ],
+    ] + list(nss_libs),
 )
 
 Return('libnssfix')

--- a/site_scons/conftest.py
+++ b/site_scons/conftest.py
@@ -14,6 +14,26 @@ int main(void)
     return ok
 
 
+def BasicCheckLib(context, libname):
+    """Check for a C library.
+
+    Similar to built-in CheckLib but works around
+    https://github.com/SCons/scons/issues/4373.
+    """
+    context.Message("Checking for library %s... " % libname)
+
+    oldLIBS = context.AppendLIBS([libname])
+    ok = context.TryLink(
+        "int main(void) { return 0; }",
+        ".c"
+    )
+    context.SetLIBS(oldLIBS)
+
+    context.Result(ok)
+    return ok
+
+
 custom_tests = dict(
     CheckNSS = CheckNSS,
+    BasicCheckLib = BasicCheckLib,
 )


### PR DESCRIPTION
Previously, `libnssfix.so` would [unconditionally link against](https://github.com/JonathonReinhart/staticx/blob/fe8c1e8de9b0ef7201ca9dcfcfeef5e311ce26f5/libnssfix/SConscript#L57) `libnss_files` and `libnss_dns`, as those are the only two libraries ("services" in NSS parlance)  specified in our [`nsswitch.conf`](https://github.com/JonathonReinhart/staticx/blob/main/libnssfix/nsswitch.conf).

As of GLIBC 2.34, the `files` and `dns` NSS "modules" are built-in to libc (https://github.com/bminor/glibc/commit/6212bb67f4695962748a5981e1b9fea105af74f6 and https://github.com/bminor/glibc/commit/e1fcf21474c5b522fdad4ac0191d5dcc3271dba6). While `libnss_files.so.2` and `libnss_dns.so.2` still exist, they are empty stubs (bminor/glibc@9ed48feed8c268e98baf00f3608d85dafb8215f3), and there are no symlinks without `.2`, which causes a link failure for us.

This PR adds a configure step to determine which NSS modules are built-in, by simply trying to link against them. Modules which are built-in are excluded from the link when building `libnssfix.so`. Because SCons/scons#4373 silently causes a false negative, we add another basic conftest called `BasicCheckLib()`.

Finally, we update the CI configuration to build under *both* Ubuntu 20.04 and 22.04. This required a creative update to the `build` job matrix, to  exclude the right Python version from the deadsnakes/action setup.

Fixes #245