### PR TITLE
Fix broken nssfix build on newer glibc (take 2)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,6 +14,8 @@ jobs:
         os:
           - version: "ubuntu-20.04"
             native-python: "3.8"
+          - version: "ubuntu-22.04"
+            native-python: "3.10"
         python-version:
           - "3.7"
           - "3.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Fixed
 - Reverted invalid fix ([#255]) for libnssfix link failure ([#262])
+- Fixed issue causing libnssfix link failure when building on GLIBC 2.34 again,
+  by linking against versioned SONAME (.2) ([#259])
 
 
 ## [0.14.0] - 2023-07-10
@@ -344,4 +346,5 @@ Initial release
 [#238]: https://github.com/JonathonReinhart/staticx/pull/238
 [#247]: https://github.com/JonathonReinhart/staticx/pull/247
 [#255]: https://github.com/JonathonReinhart/staticx/pull/255
+[#259]: https://github.com/JonathonReinhart/staticx/pull/259
 [#262]: https://github.com/JonathonReinhart/staticx/pull/262

--- a/libnssfix/SConscript
+++ b/libnssfix/SConscript
@@ -22,6 +22,18 @@ env.NsswitchConfH(
     source = nsswitch_conf,
 )
 
+def ld_lib_filename(libname):
+    # From ld(1):
+    #   If namespec is of the form `:filename`, ld will search
+    #   the library path for a file called `filename`.
+    return ":" + libname
+
+# Link against the configured NSS module libraries.
+# These aren't needed directly for the library itself, but this ensures
+# that they will be available for nss at runtime (via dlopen), and
+# allows their paths to be easily discovered via ldd(1).
+nss_libs = [ld_lib_filename(libname) for libname in env.GetNsswitchLibs(nsswitch_conf)]
+
 # Build libnssfix.so
 libnssfix = env.SharedLibrary(
     target = 'nssfix',
@@ -50,12 +62,7 @@ libnssfix = env.SharedLibrary(
     ],
     LIBS = [
         libc_stub,
-
-        # These aren't needed directly for the library itself, but this ensures
-        # that they will be available for nss at runtime (via dlopen), and
-        # allows their paths to be easily discovered via ldd(1).
-        env.GetNsswitchLibs(nsswitch_conf),
-    ],
+    ] + nss_libs,
 )
 
 Return('libnssfix')

--- a/site_scons/site_tools/nsswitchconf.py
+++ b/site_scons/site_tools/nsswitchconf.py
@@ -29,12 +29,27 @@ def NsswitchConfH(env, target, source):
         source = source,
     )
 
+# https://www.gnu.org/software/libc/manual/html_node/Adding-another-Service-to-NSS.html
+# https://www.gnu.org/software/libc/manual/html_node/NSS-Module-Names.html
+def _nss_module_name(service):
+    NSS_INTERFACE_VERSION = 2
+    return f"libnss_{service}.so.{NSS_INTERFACE_VERSION}"
+
 def GetNsswitchLibs(env, source):
+    """Gets a list of NSS module names for the given nsswitch.conf
+
+    Args:
+      env: Construction environment
+      source: nsswitch.conf configuration file
+    Returns:
+      A list of module names for the services configured in nsswitch.conf.
+      Example: ["libnss_files.so.2", "libnss_dns.so.2"]
+    """
     source = env.File(source)
     libs = set()
     conf = read_nsswitch_conf(source.srcnode().abspath)
     for dbname, svcs in conf:
-        libs.update('libnss_'+s for s in svcs)
+        libs.update(_nss_module_name(svc) for svc in svcs)
     return list(libs)
 
 def generate(env):

--- a/test/no-default-lib/run_test.sh
+++ b/test/no-default-lib/run_test.sh
@@ -29,10 +29,9 @@ $outfile $libname 1 || exit $?
 ### Docker
 libname="libcrack.so"
 
-# Run the original app under docker
 if [ -n "$TEST_DOCKER_IMAGE" ]; then
-    echo -e "\nRunning original app under $TEST_DOCKER_IMAGE"
-    scuba --image $TEST_DOCKER_IMAGE $app $libname 0
+    echo -e "\nVerifying target library is loadable under $TEST_DOCKER_IMAGE"
+    scuba --image $TEST_DOCKER_IMAGE /bin/bash -c "ldd /usr/sbin/cracklib-check | grep libcrack.so"
 
     echo -e "\nRunning staticx executable under $TEST_DOCKER_IMAGE"
     scuba --image $TEST_DOCKER_IMAGE $outfile $libname 1


### PR DESCRIPTION
This takes a different approach than #255 by simply linking against the `libnss_*.so.2` SONAME explicitly, rather than the normal method of passing `-lnss_*`. This works because the `.so.2` stubs still exist on GLIBC >=2.34.

Fixes #245 (take 2)