### PR TITLE
staticx: Don't raise exception from is_dynamic_elf

### DIFF
--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -154,7 +154,8 @@ def get_shobj_deps(path, libpath=None):
     """
 
     # First verify we're dealing with a dynamic ELF file
-    ensure_dynamic(path)
+    if not is_dynamic_elf(path):
+        raise StaticELFError(path=path)
 
     # Prepare the environment
     keep_vars = {'LD_LIBRARY_PATH'}
@@ -328,10 +329,9 @@ def get_prog_interp(path):
     with open_elf(path) as elf:
         return elf.get_prog_interp()
 
-def is_dynamic(path):
-    with open_elf(path) as elf:
-        return elf.is_dynamic()
-
-def ensure_dynamic(path):
-    if not is_dynamic(path):
-        raise StaticELFError(path=path)
+def is_dynamic_elf(path):
+    try:
+        with ELFFileX.open(path, mode='rb') as elf:
+            return elf.is_dynamic()
+    except ELFError as e:
+        return False

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -2,7 +2,7 @@ import os
 import logging
 import tempfile
 
-from ..elf import get_shobj_deps, is_dynamic, LddError
+from ..elf import get_shobj_deps, is_dynamic_elf, LddError
 from ..errors import Error, UnsupportedRpathError, UnsupportedRunpathError
 from ..utils import make_executable, mkdirs_for
 
@@ -68,7 +68,7 @@ class PyInstallHook:
         # These could be Python libraries, shared object dependencies, or
         # anything else a user might add via `binaries` in the .spec file.
         # Filter out everything except dynamic ELFs
-        binaries = [b for b in binaries if is_dynamic(b)]
+        binaries = [b for b in binaries if is_dynamic_elf(b)]
 
         self._audit_libs(binaries)
 


### PR DESCRIPTION
Previously, if a non-ELF file appeared in a PyInstaller archive as a "binary" file, staticx would crash when open_elf() raised an InvalidInputError.

Rename is_dynamic() to is_dynamic_elf() to make it clear that it now returns False if the file is not an ELF file at all.

Fixes #268.