### PR TITLE
staticx: Use importlib.metadata over pkg_resources for getting version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
 ]
 dependencies = [
     "pyelftools",
+    # TODO(#264): Remove when Python 3.7 support is removed.
+    "importlib_metadata; python_version<'3.8'",
 ]
 description = "Build static self-extracting app from dynamic executable"
 license = {file = "LICENSE.txt"}
@@ -44,4 +46,6 @@ changelog = "https://github.com/JonathonReinhart/staticx/blob/main/CHANGELOG.md"
 requires = [
     "wheel",
     "setuptools >= 42.0.0",
+    # TODO(#264): Remove when Python 3.7 support is removed.
+    "importlib_metadata; python_version<'3.8'",
 ]

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -8,6 +8,8 @@ import sys
 PACKAGEPATH = Path(__file__).absolute().parent
 PROJPATH = PACKAGEPATH.parent
 
+DIST_SPEC = 'staticx'
+
 # Base version, which will be augmented with Git information
 BASE_VERSION = '0.14.1'
 
@@ -57,19 +59,17 @@ def get_version():
         return f'{BASE_VERSION}+g{git_archive_rev}'
 
 
-    # Package resource
     # Otherwise, we're either installed (e.g. via pip), or running from
     # an 'sdist' source distribution, and have a local PKG_INFO file.
-    import pkg_resources
-    try:
-        return pkg_resources.get_distribution('staticx').version
-    except pkg_resources.DistributionNotFound:
-        pass
 
+    # TODO(#242): Remove backport when Python 3.7 support is removed.
+    if sys.version_info >= (3, 8):
+        import importlib.metadata as importlib_metadata
+    else:
+        import importlib_metadata  # backport
 
-    # This shouldn't be able to happen
-    sys.stderr.write('WARNING: Failed to determine version!\n')
-    return BASE_VERSION
+    # Can raise importlib.metadata.PackageNotFoundError
+    return importlib_metadata.version(DIST_SPEC)
 
 
 __version__ = get_version()


### PR DESCRIPTION
pkg_resources is deprecated:
https://setuptools.pypa.io/en/latest/pkg_resources.html

This prefers importlib.metadata (introduced in Python 3.8) and uses the backport importlib_metadata for Python 3.7 (to be removed in #264).

Fixes #266

Reference: https://github.com/JonathonReinhart/scuba/pull/247