### PR TITLE
staticx: Use importlib.resources over pkg_resources for asset access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - Introduced `pyproject.toml` and moved metadata from `setup.py` (#267)
-- Removed use of deprecated `pkg_resources` (#271)
+- Removed use of deprecated `pkg_resources` (#271, #274)
 
 ### Fixed
 - Fixed an issue with non-ELF "binary" files in PyInstaller archives causing a crash (#270)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "pyelftools",
     # TODO(#264): Remove when Python 3.7 support is removed.
     "importlib_metadata; python_version<'3.8'",
+    # TODO(#265): Remove when Python 3.8 support is removed.
+    "importlib_resources; python_version<'3.9'",
 ]
 description = "Build static self-extracting app from dynamic executable"
 license = {file = "LICENSE.txt"}

--- a/staticx/assets.py
+++ b/staticx/assets.py
@@ -1,11 +1,19 @@
-import pkg_resources
+import sys
 from .utils import copy_fileobj_to_tempfile
+
+# TODO(#265): Remove backport when Python 3.8 support is removed.
+# importlib.resources.files() was added in Python 3.9.
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources  # backport
+
 
 def locate_asset(name, debug):
     mode = 'debug' if debug else 'release'
     path = '/'.join(('assets', mode, name))
     try:
-        return pkg_resources.resource_stream(__name__, path)
+        return importlib_resources.files("staticx").joinpath(path).open("rb")
     except FileNotFoundError:
         raise KeyError(f"Asset not found: {name!r} (mode={mode!r})")
 

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -62,7 +62,7 @@ def get_version():
     # Otherwise, we're either installed (e.g. via pip), or running from
     # an 'sdist' source distribution, and have a local PKG_INFO file.
 
-    # TODO(#242): Remove backport when Python 3.7 support is removed.
+    # TODO(#264): Remove backport when Python 3.7 support is removed.
     if sys.version_info >= (3, 8):
         import importlib.metadata as importlib_metadata
     else:


### PR DESCRIPTION
Replace `pkg_resources.resource_stream()` with `importlib_resources.files().joinpath().open()`.

Fixes #266 (again).