### PR TITLE
Feature: CLI options for bundle directory and program name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/bootloader/common.h
+++ b/bootloader/common.h
@@ -5,6 +5,7 @@
 #define ARCHIVE_SECTION         ".staticx.archive"
 #define INTERP_FILENAME         ".staticx.interp"
 #define PROG_FILENAME           ".staticx.prog"
+#define BUNDLE_DIR_FILENAME     ".staticx.bundle-dir"
 
 static inline void *
 ptr_add(void *p, size_t off)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,11 +3,12 @@ Usage
 
 Synopsis
 --------
-.. code-block::
+.. code-block:: shell
 
    staticx [-h]
-           [-l LIB] [--strip] [--no-compress] [-V]
-           [--loglevel LEVEL]
+           [-l LIB] [--strip] [--no-compress]
+           [--bundle-dir BUNDLE_DIR] [--prog-name PROG_NAME]
+           [-V] [--loglevel LEVEL]
            PROG OUTPUT
 
 Positional Arguments:
@@ -19,12 +20,17 @@ Positional Arguments:
 
 Options:
   -h, --help            Show help message and exit
+
   -l LIB                Add additional library (absolute path)
 
                         This option can be given multiple times.
 
   --strip               Strip binaries before adding to archive (reduces size)
   --no-compress         Don't compress the archive (increases size)
+  --bundle-dir BUNDLE_DIR
+                        The directory that the program extracts to at runtime. When not specified, staticx extracts to ``/tmp/staticx-XXXXXX``.
+  --prog-name PROG_NAME
+                        The name that the program extracts to at runtime. When not specified, staticx uses the name of the input program.
   --loglevel LEVEL      Set the logging level (default: WARNING)
 
                         Options: DEBUG,INFO,WARNING,ERROR,CRITICAL
@@ -70,6 +76,5 @@ Run-time Information
 --------------------
 StaticX sets the following environment variables for the wrapped user program:
 
-- ``STATICX_BUNDLE_DIR``: The absolute path of the "bundle" directory, the
-  temporary dir where the archive has been extracted.
-- ``STATICX_PROG_PATH``: The absolute path of the program being executed.
+- ``STATICX_BUNDLE_DIR``: The absolute path of the "bundle" directory, a temporary directory, where the archive has been extracted.
+- ``STATICX_PROG_PATH``: The absolute path of the program being executed (not the extracted program in the bundle directory).

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -24,6 +24,10 @@ def parse_args():
             help = 'Strip binaries before adding to archive (reduces size)')
     ap.add_argument('--no-compress', action='store_true',
             help = "Don't compress the archive (increases size)")
+    ap.add_argument('--bundle-dir',
+            help = 'The directory that the program extracts to at runtime. When not specified, staticx extracts to /tmp/staticx-XXXXXX.')
+    ap.add_argument('--prog-name',
+            help = 'The name that the program extracts to at runtime. When not specified, staticx uses the name of the input program.')
 
     # Special / output-related options
     ap.add_argument('-V', '--version', action='version',

--- a/staticx/__main__.py
+++ b/staticx/__main__.py
@@ -54,8 +54,9 @@ def main():
                 libs = args.libs,
                 strip = args.strip,
                 compress = not args.no_compress,
-                debug = args.debug,
-                )
+                bundle_dir = args.bundle_dir,
+                prog_name = args.prog_name,
+                debug = args.debug)
     except Error as e:
         if args.debug:
             raise

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -25,9 +25,13 @@ class StaticxGenerator:
 
     def __init__(self, prog, strip=False, compress=True, bundle_dir=None, prog_name=None, debug=False, cleanup=True):
         """
-        Parameters:
-        prog:   Dynamic executable to staticx
-        debug:  Run in debug mode (use debug bootloader)
+            Parameters:
+            prog:       Dynamic executable to staticx
+            strip:      Strip binaries to reduce size
+            compress:   Whether or not to compress the archive
+            bundle_dir: The directory that the program extracts to at runtime
+            prog_name:  The name that the program extracts to at runtime
+            debug:      Run in debug mode (use debug bootloader)
         """
         self.orig_prog = prog
         self.strip = strip
@@ -137,6 +141,8 @@ class StaticxGenerator:
 
             ar.add_program(self.tmpprog, self.prog_name or basename(self.orig_prog))
             ar.add_interp_symlink(orig_interp)
+            if self.bundle_dir is not None:
+                ar.add_bundle_dir_symlink(self.bundle_dir)
 
             # Add all of the libraries
             for libpath in get_shobj_deps(self.orig_prog):
@@ -300,11 +306,14 @@ def generate(prog, output, libs=None, strip=False, compress=True, bundle_dir=Non
     """Main API: Generate a staticx executable
 
     Parameters:
-    prog:   Dynamic executable to staticx
-    output: Path to result
-    libs: Extra libraries to include
-    strip: Strip binaries to reduce size
-    debug: Run in debug mode (use debug bootloader)
+    prog:       Dynamic executable to staticx
+    output:     Path to result
+    libs:       Extra libraries to include
+    strip:      Strip binaries to reduce size
+    compress:   Whether or not to compress the archive
+    bundle_dir: The directory that the program extracts to at runtime
+    prog_name:  The name that the program extracts to at runtime
+    debug:      Run in debug mode (use debug bootloader)
     """
 
     logging.info(f"Running StaticX version {__version__}")

--- a/staticx/api.py
+++ b/staticx/api.py
@@ -23,7 +23,7 @@ class StaticxGenerator:
     """StaticxGenerator is responsible for producing a staticx-ified executable.
     """
 
-    def __init__(self, prog, strip=False, compress=True, debug=False, cleanup=True):
+    def __init__(self, prog, strip=False, compress=True, bundle_dir=None, prog_name=None, debug=False, cleanup=True):
         """
         Parameters:
         prog:   Dynamic executable to staticx
@@ -32,6 +32,8 @@ class StaticxGenerator:
         self.orig_prog = prog
         self.strip = strip
         self.compress = compress
+        self.bundle_dir = bundle_dir
+        self.prog_name = prog_name
         self.debug = debug
         self.cleanup = cleanup
 
@@ -133,7 +135,7 @@ class StaticxGenerator:
         with self.sxar as ar:
             run_hooks(self)
 
-            ar.add_program(self.tmpprog, basename(self.orig_prog))
+            ar.add_program(self.tmpprog, self.prog_name or basename(self.orig_prog))
             ar.add_interp_symlink(orig_interp)
 
             # Add all of the libraries
@@ -294,7 +296,7 @@ class StaticxGenerator:
                   force_rpath=True, no_default_lib=True)
 
 
-def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
+def generate(prog, output, libs=None, strip=False, compress=True, bundle_dir=None, prog_name=None, debug=False):
     """Main API: Generate a staticx executable
 
     Parameters:
@@ -319,8 +321,9 @@ def generate(prog, output, libs=None, strip=False, compress=True, debug=False):
             prog=prog,
             strip=strip,
             compress=compress,
-            debug=debug,
-            )
+            bundle_dir=bundle_dir,
+            prog_name=prog_name,
+            debug=debug)
     with gen:
         for lib in (libs or []):
             gen.add_library(lib)

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -129,3 +129,7 @@ class SxArchive:
     def add_interp_symlink(self, interp):
         """Add symlink for ld.so interpreter"""
         self.add_symlink(INTERP_FILENAME, basename(interp))
+    
+    def add_bundle_dir_symlink(self, bundle_dir):
+        """Adds a symlink that holds the path that the bundle directory will be moved to."""
+        self.add_symlink(BUNDLE_DIR_FILENAME, bundle_dir)

--- a/staticx/constants.py
+++ b/staticx/constants.py
@@ -1,6 +1,7 @@
-ARCHIVE_SECTION = ".staticx.archive"
-INTERP_FILENAME = ".staticx.interp"
-PROG_FILENAME   = ".staticx.prog"
+ARCHIVE_SECTION     = ".staticx.archive"
+INTERP_FILENAME     = ".staticx.interp"
+PROG_FILENAME       = ".staticx.prog"
+BUNDLE_DIR_FILENAME = ".staticx.bundle-dir"
 
 MAX_INTERP_LEN = 256
 MAX_RPATH_LEN = 256

--- a/test/bundle-dir-prog-name.sh
+++ b/test/bundle-dir-prog-name.sh
@@ -26,7 +26,7 @@ if [[ "$test_bundle_dir" != "$bundle_dir" ]]; then
 fi
 
 # Verify that the program is renamed to `--prog-name` when specified.
-test_prog_name=$($outfile -c 'echo $0')
+test_prog_name=$($outfile -c 'basename $0')
 echo "The program name is: $test_prog_name"
 if [[ "$test_prog_name" != "$prog_name" ]]; then
     echo "The program name does not match --prog-name: \"$test_prog_name\" != \"$prog_name\""

--- a/test/bundle-dir-prog-name.sh
+++ b/test/bundle-dir-prog-name.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+echo -e "\n\n--------------------------------------------------------------------------------"
+echo -e "Test StaticX --bundle-dir and --prog-name options."
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+app="$(which sh)"
+outfile="./sh.staticx"
+
+# The values we're going to be testing for.
+bundle_dir=$(mktemp --dry-run --tmpdir -d systemd-private-60ce0209a865480b817f3623184c43e2-dmesg.service-XXXXXX)
+prog_name="tmp"
+
+# Make a staticx executable from bash so we can check the STATICX_ env vars to know the bundle directory and program path.
+echo -e "\nMaking staticx executable (\$STATICX_FLAGS=$STATICX_FLAGS):"
+staticx $STATICX_FLAGS --bundle-dir $bundle_dir --prog-name $prog_name $app $outfile
+
+# Verify STATICX_BUNDLE_DIR matches the `--bundle-dir` option.
+test_bundle_dir=$($outfile -c 'echo $STATICX_BUNDLE_DIR')
+echo "STATICX_BUNDLE_DIR: $test_bundle_dir"
+if [[ "$test_bundle_dir" != "$bundle_dir" ]]; then
+    echo "STATICX_BUNDLE_DIR does not match --bundle-dir: \"$test_bundle_dir\" != \"$bundle_dir\""
+    exit 1
+fi
+
+# Verify that the program is renamed to `--prog-name` when specified.
+test_prog_name=$($outfile -c 'echo $0')
+echo "The program name is: $test_prog_name"
+if [[ "$test_prog_name" != "$prog_name" ]]; then
+    echo "The program name does not match --prog-name: \"$test_prog_name\" != \"$prog_name\""
+    exit 1
+fi

--- a/test/run_all.sh
+++ b/test/run_all.sh
@@ -9,6 +9,9 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 # Test environment variables
 ./staticx-env-vars.sh
 
+# Test --bundle-dir and --prog-name options
+./bundle-dir-prog-name.sh
+
 # Run test an executable linked against musl-libc
 musl/run_test.sh
 


### PR DESCRIPTION
WIP for #282. `--bundle-dir` will determine where the bootloader extracts the archive to. `--prog-name` will determine the name of the program within the archive. For example:

```shell
# We can specify the new options like so:
staticx --bundle-dir /tmp/ssh-6YD5uj0Xx7wI --prog-name agent.1542 myprogram ssh-agent

# And when we run the staticx program,
./ssh-agent
# it will extract to the folder /tmp/ssh-6YD5uj0Xx7wI,
# and the program will be extracted to /tmp/ssh-6YD5uj0Xx7wI/agent.1542

# The program will show up as two processes in a process listing:
# ./myprog and its child process /tmp/ssh-6YD5uj0Xx7wI/agent.1542
```

## Checklist
### Testing
Testing done in `test/bundle-dir-prog-name.sh`.
- [x] Testing that `$STATICX_BUNDLE_DIR` is the same as `--bundle-dir`.
- [x] Testing that `basename $0` is the same as `--prog-name`.

### CLI
- [x] Added option `--bundle-dir` with help message.
- [x] Added option `--prog-name` with help message.

### Documentation
- [x] Added `--bundle-dir` and `--prog-name` under the `docs/usage.rst`.
- [x] Updated old python functions docstrings to include `--bundle-dir` and `--prog-name`.
- [x] Documented new C functions `get_symlink`, `move_bundle`, and `file_exists`.
- [x] Documented new Python function `add_bundle_dir_symlink`.

### Implementation
#### `--prog-name`
- [x] When adding the modified program to the archive, use `--prog-name` when specified instead of the `basename` of positional argument `prog`.

#### `--bundle-dir`
Unfortunately, I don't have the C skills to have it extract directly to the new bundle directory, so my solution here is to extract to the `/tmp/staticx-XXXXXX` and then move it to the new bundle directory, which is obviously not ideal. **If anyone has any ideas about how to read the TAR archive to get the symlink before extracting please feel free to jump in.**

- [x] Add a symlink file to the archive for `--bundle-dir`.
- [x] In the bootloader, check if the file exists.
- [x] If it does, read the symlink and move the bundle directory to the symlink's value.