### PR TITLE
Release v0.14.2

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -53,7 +53,7 @@ jobs:
         python -m build
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-dist
         path: dist/
@@ -120,7 +120,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-dist
         path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.14.2]
 ### Added
 - Added support for Python 3.12 (#272)
 
@@ -264,7 +264,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 Initial release
 
 
-[Unreleased]: https://github.com/JonathonReinhart/staticx/compare/v0.14.1...HEAD
+[Unreleased]: https://github.com/JonathonReinhart/staticx/compare/v0.14.2...HEAD
+[0.14.2]: https://github.com/JonathonReinhart/staticx/compare/v0.14.1...HEAD
 [0.14.1]: https://github.com/JonathonReinhart/staticx/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/JonathonReinhart/staticx/compare/v0.13.9...v0.14.0
 [0.13.9]: https://github.com/JonathonReinhart/staticx/compare/v0.13.8...v0.13.9

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -11,7 +11,7 @@ PROJPATH = PACKAGEPATH.parent
 DIST_SPEC = 'staticx'
 
 # Base version, which will be augmented with Git information
-BASE_VERSION = '0.14.1'
+BASE_VERSION = '0.14.2'
 
 # This string will be replaced by `git-archive`
 # with the abbreviated commit hash


### PR DESCRIPTION
Currently `pkg_resources` was removed in `setuptools v82.0.0`, so it is critical to providing a release with fixes that implemented in #274.
```
    |   warn(
    | Traceback (most recent call last):
    |   File "/usr/local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    |     main()
    |   File "/usr/local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    |     json_out["return_val"] = hook(**hook_input["kwargs"])
    |   File "/usr/local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
    |     return hook(config_settings)
    |   File "/tmp/tmpbptn4ef9/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
    |     return self._get_build_requires(config_settings, requirements=[])
    |   File "/tmp/tmpbptn4ef9/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
    |     self.run_setup()
    |   File "/tmp/tmpbptn4ef9/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 520, in run_setup
    |     super().run_setup(setup_script=setup_script)
    |   File "/tmp/tmpbptn4ef9/.venv/lib/python3.10/site-packages/setuptools/build_meta.py", line 317, in run_setup
    |     exec(code, locals())
    |   File "<string>", line 124, in <module>
    |   File "<string>", line 15, in get_dynamic_version
    |   File "/tmp/tmp42pki9ed/staticx-0.14.1/staticx/version.py", line 75, in <module>
    |     __version__ = get_version()
    |   File "/tmp/tmp42pki9ed/staticx-0.14.1/staticx/version.py", line 63, in get_version
    |     import pkg_resources
    | ModuleNotFoundError: No module named 'pkg_resources'
```

Beside that, I fixed workflow by use v4 artifact action since v3 is no longer supported https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/