### PR TITLE
Leverage Python 3.10 language features

### DIFF
--- a/staticx/api.py
+++ b/staticx/api.py
@@ -10,7 +10,6 @@ from os.path import basename, islink
 import logging
 import subprocess
 from types import TracebackType
-from typing import Optional
 
 from .errors import (
     FormatMismatchError,
@@ -47,16 +46,16 @@ class StaticxGenerator:
     """StaticxGenerator is responsible for producing a staticx-ified executable.
     """
     # Temporary output file (copy of bootloader to be modified)
-    tmpoutput: Optional[str]
+    tmpoutput: str | None
 
     # Temporary copy of user program to be modified
-    tmpprog: Optional[str]
+    tmpprog: str | None
 
     # Temporary working directory
-    tmpdir: Optional[str]
+    tmpdir: str | None
 
     # Staticx archive being populated
-    sxar: Optional[SxArchive]
+    sxar: SxArchive | None
 
     def __init__(self,
                  prog: str,
@@ -76,7 +75,7 @@ class StaticxGenerator:
         self.cleanup = cleanup
 
         self._generate_called = False
-        self._added_libs: dict[str, Optional[str]] = {}  # arcname => libpath (or None for symlink)
+        self._added_libs: dict[str, str | None] = {}  # arcname => libpath (or None for symlink)
 
         # Temporary output file (bootloader copy)
         self.tmpoutput = None
@@ -91,9 +90,9 @@ class StaticxGenerator:
         return self
 
     def __exit__(self,
-                 type: Optional[type[BaseException]],
-                 value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> None:
+                 type: type[BaseException] | None,
+                 value: BaseException | None,
+                 traceback: TracebackType | None) -> None:
         if self.cleanup:
             self._cleanup()
 
@@ -347,7 +346,7 @@ class StaticxGenerator:
 def generate(
     prog: str,
     output: str,
-    libs: Optional[list[str]] = None,
+    libs: list[str] | None = None,
     strip: bool = False,
     compress: bool = True,
     debug: bool = False,

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -5,8 +5,7 @@ import logging
 import lzma
 from os.path import basename
 from types import TracebackType
-from typing import IO, TypeAlias
-from typing_extensions import Literal
+from typing import IO, Literal, TypeAlias
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -5,7 +5,7 @@ import logging
 import lzma
 from os.path import basename
 from types import TracebackType
-from typing import IO
+from typing import IO, TypeAlias
 from typing_extensions import Literal
 
 from typing import TYPE_CHECKING
@@ -34,9 +34,9 @@ def get_bcj_filter() -> BcjFilter | None:
         name=filt_name,
     )
 
-LzmaFilterChain = list[dict[str, str | int]]
+LzmaFilterChain: TypeAlias = list[dict[str, str | int]]
 
-def get_xz_filters() -> list[dict[str, str | int]]:
+def get_xz_filters() -> LzmaFilterChain:
     filters: LzmaFilterChain = []
 
     # Get a BCJ filter for the current architecture

--- a/staticx/archive.py
+++ b/staticx/archive.py
@@ -5,7 +5,7 @@ import logging
 import lzma
 from os.path import basename
 from types import TracebackType
-from typing import IO, Optional, Union
+from typing import IO
 from typing_extensions import Literal
 
 from typing import TYPE_CHECKING
@@ -22,7 +22,7 @@ class BcjFilter:
     name: str
 
 
-def get_bcj_filter() -> Optional[BcjFilter]:
+def get_bcj_filter() -> BcjFilter | None:
     arch = get_bcj_filter_arch()
     if not arch:
         return None
@@ -34,9 +34,9 @@ def get_bcj_filter() -> Optional[BcjFilter]:
         name=filt_name,
     )
 
-LzmaFilterChain = list[dict[str, Union[str, int]]]
+LzmaFilterChain = list[dict[str, str | int]]
 
-def get_xz_filters() -> list[dict[str, Union[str, int]]]:
+def get_xz_filters() -> list[dict[str, str | int]]:
     filters: LzmaFilterChain = []
 
     # Get a BCJ filter for the current architecture
@@ -51,7 +51,7 @@ def get_xz_filters() -> list[dict[str, Union[str, int]]]:
 
 class SxArchive:
     fileobj: IO[bytes]
-    xzf: Optional[lzma.LZMAFile]
+    xzf: lzma.LZMAFile | None
     tar: tarfile.TarFile
 
     def __init__(self, fileobj: IO[bytes], mode: Literal["r", "w"], compress: bool):
@@ -89,9 +89,9 @@ class SxArchive:
         return self
 
     def __exit__(self,
-                 type: Optional[type[BaseException]],
-                 value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> None:
+                 type: type[BaseException] | None,
+                 value: BaseException | None,
+                 traceback: TracebackType | None) -> None:
         self.close()
 
     def close(self) -> None:
@@ -140,7 +140,7 @@ class SxArchive:
         # Store a link to the program so the bootloader knows what to execute
         self.add_symlink(PROG_FILENAME, name)
 
-    def add_file(self, path: StrPath, arcname: Optional[StrPath] = None) -> None:
+    def add_file(self, path: StrPath, arcname: StrPath | None = None) -> None:
         self.tar.add(path, arcname=arcname)
 
     def add_interp_symlink(self, interp: str) -> None:

--- a/staticx/bcjfilter.py
+++ b/staticx/bcjfilter.py
@@ -1,9 +1,8 @@
 import platform
-from typing import Optional
 
 # NOTE: This is also used by libxz/SConscript
 
-def get_bcj_filter_arch() -> Optional[str]:
+def get_bcj_filter_arch() -> str | None:
     """
     Get an appropriate BCJ filter for the current architecture.
 

--- a/staticx/bcjfilter.py
+++ b/staticx/bcjfilter.py
@@ -16,23 +16,16 @@ def get_bcj_filter_arch() -> str | None:
     # This approach should be "good enough"; the worst case scenario is only a
     # slightly worse compression ratio.
 
-    machine = platform.machine()
-
-    if machine in ('i386', 'i686', 'x86_64'):
-        return 'X86'
-
-    if machine == 'ia64':
-        return 'IA64'
-
-    if machine.startswith('arm'):   # arm, armv8b, etc.
-        return 'ARM'
-
-    # TODO: 'ARMTHUMB'
-
-    if machine.startswith('ppc'):
-        return 'POWERPC'
-
-    if machine.startswith('sparc'):
-        return 'SPARC'
-
-    return None
+    match platform.machine():
+        case 'i386' | 'i686' | 'x86_64':
+            return 'X86'
+        case 'ia64':
+            return 'IA64'
+        case m if m.startswith('arm'):   # arm, armv8b, etc.
+            return 'ARM'
+        case m if m.startswith('ppc'):
+            return 'POWERPC'
+        case m if m.startswith('sparc'):
+            return 'SPARC'
+        case _:
+            return None

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -19,7 +19,12 @@ from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import Section
 from elftools.elf.segments import InterpSegment
 
-from .errors import *
+from .errors import (
+    Error,
+    InvalidInputError,
+    MissingToolError,
+    ToolError,
+)
 from .utils import coerce_sequence, single
 
 

--- a/staticx/elf.py
+++ b/staticx/elf.py
@@ -10,7 +10,7 @@ import errno
 import os
 from os import PathLike
 from types import TracebackType
-from typing import Any, BinaryIO, Optional, Union
+from typing import Any, BinaryIO
 
 import elftools
 from elftools.common.exceptions import ELFError
@@ -31,7 +31,7 @@ def verify_tools() -> None:
 
 
 class ExternTool:
-    def __init__(self, cmd: str, os_pkg: str, stderr_ignore: list[str] = [], encoding: Optional[str] = None):
+    def __init__(self, cmd: str, os_pkg: str, stderr_ignore: list[str] = [], encoding: str | None = None):
         self.cmd = cmd
         self.os_pkg = os_pkg
         self.stderr_ignore = stderr_ignore
@@ -160,7 +160,7 @@ def _parse_ldd_output(output: str) -> Iterable[str]:
         yield libpath
 
 
-def get_shobj_deps(path: str, libpath: Optional[list[str]] = None) -> list[str]:
+def get_shobj_deps(path: str, libpath: list[str] | None = None) -> list[str]:
     """Discover the dependencies of a shared object (*.so file)
     """
 
@@ -223,11 +223,11 @@ def elf_dump_section(elfpath: str, secname: str, outpath: str) -> None:
 
 def patch_elf(
     path: str,
-    interpreter: Optional[str] = None,
-    rpath: Optional[str] = None,
+    interpreter: str | None = None,
+    rpath: str | None = None,
     force_rpath: bool = False,
     no_default_lib: bool = False,
-    add_needed: Union[list[str], str, None] = None,
+    add_needed: list[str] | str | None = None,
 ) -> None:
     args = []
     if interpreter:
@@ -272,7 +272,7 @@ class StaticELFError(Error):
         super().__init__(message)
 
 class ELFFileX(ELFFile):
-    def __init__(self, stream: BinaryIO, path: Optional[str] = None):
+    def __init__(self, stream: BinaryIO, path: str | None = None):
         self.__path = path
         super().__init__(stream)
 
@@ -284,13 +284,13 @@ class ELFFileX(ELFFile):
         return self
 
     def __exit__(self,
-                 type: Optional[type[BaseException]],
-                 value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> None:
+                 type: type[BaseException] | None,
+                 value: BaseException | None,
+                 traceback: TracebackType | None) -> None:
         self.stream.close()
 
     # TODO: Constrain return section type to sectype arg
-    def get_single_section(self, sectype: type[Section]) -> Optional[Section]:
+    def get_single_section(self, sectype: type[Section]) -> Section | None:
         """Returns the only section of a given type, or None if absent"""
         key = lambda sec: isinstance(sec, sectype)
         return single(self.iter_sections(), key=key, default=None)
@@ -305,7 +305,7 @@ class ELFFileX(ELFFile):
             f"{self.__path}: not a dynamic executable (no interp segment)")
 
 
-    def get_dynamic_segment(self) -> Optional[DynamicSegment]:
+    def get_dynamic_segment(self) -> DynamicSegment | None:
         for seg in self.iter_segments():
             if seg['p_type'] == 'PT_DYNAMIC':
                 assert isinstance(seg, DynamicSegment)
@@ -315,17 +315,17 @@ class ELFFileX(ELFFile):
     def is_dynamic(self) -> bool:
         return bool(self.get_dynamic_segment())
 
-    def get_single_dynamic_tag(self, name: str) -> Optional[DynamicTag]:
+    def get_single_dynamic_tag(self, name: str) -> DynamicTag | None:
         dyn = self.get_dynamic_segment()
         if dyn:
             return single(dyn.iter_tags(name), default=None)
         return None
 
-    def get_rpath(self) -> Optional[DynamicTag]:
+    def get_rpath(self) -> DynamicTag | None:
         """Returns the value of the DT_RPATH tag of the ELF file"""
         return self.get_single_dynamic_tag('DT_RPATH')
 
-    def get_runpath(self) -> Optional[DynamicTag]:
+    def get_runpath(self) -> DynamicTag | None:
         """Returns the value of the DT_RUNPATH tag of the ELF file"""
         return self.get_single_dynamic_tag('DT_RUNPATH')
 

--- a/staticx/errors.py
+++ b/staticx/errors.py
@@ -1,6 +1,5 @@
 import abc
 from pathlib import Path
-from typing import Union
 
 class Error(Exception):
     """Base type for all exceptions raised by staticx"""
@@ -68,7 +67,7 @@ class LibExistsError(ArchiveError):
 
 class DirectoryExistsError(Error):
     """A given directory already exists"""
-    def __init__(self, path: Union[Path, str]):
+    def __init__(self, path: Path | str):
         super().__init__(
                 f"{path}: is a directory")
         self.path = path

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -4,7 +4,7 @@ import os
 import logging
 import tempfile
 from types import TracebackType
-from typing import Any, Optional, Union
+from typing import Any
 from typing import TYPE_CHECKING
 
 from ..elf import get_shobj_deps, is_dynamic_elf, LddError
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ..api import StaticxGenerator
     from PyInstaller.archive.readers import CArchiveReader, _TocEntry
 
-    UArchiveReader = Union[CArchiveReader, CArchiveReaderPre510Adapter]  # type: ignore [used-before-def]
+    UArchiveReader = CArchiveReader | CArchiveReaderPre510Adapter  # type: ignore [used-before-def]
 
     # NOTE: mypy doesn't support selecting different stubs based on library
     # version, so we simply punt and declare this as Any.
@@ -76,9 +76,9 @@ class PyInstallHook:
         return self
 
     def __exit__(self,
-                 type: Optional[type[BaseException]],
-                 value: Optional[BaseException],
-                 traceback: Optional[TracebackType]) -> None:
+                 type: type[BaseException] | None,
+                 value: BaseException | None,
+                 traceback: TracebackType | None) -> None:
         self.tmpdir.cleanup()
 
     def process(self) -> None:

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -4,7 +4,7 @@ import os
 import logging
 import tempfile
 from types import TracebackType
-from typing import Any
+from typing import Any, TypeAlias
 from typing import TYPE_CHECKING
 
 from ..elf import get_shobj_deps, is_dynamic_elf, LddError
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from ..api import StaticxGenerator
     from PyInstaller.archive.readers import CArchiveReader, _TocEntry
 
-    UArchiveReader = CArchiveReader | CArchiveReaderPre510Adapter  # type: ignore [used-before-def]
+    UArchiveReader: TypeAlias = CArchiveReader | CArchiveReaderPre510Adapter  # type: ignore [used-before-def]
 
     # NOTE: mypy doesn't support selecting different stubs based on library
     # version, so we simply punt and declare this as Any.

--- a/staticx/hooks/pyinstaller.py
+++ b/staticx/hooks/pyinstaller.py
@@ -51,15 +51,15 @@ def process_pyinstaller_archive(sx: StaticxGenerator) -> None:
     # enough to detect this way.
     # We do this after opening the archive to avoid failing for non-pyinstalled
     # input files.
-    if pyi_version[:2] in ((4, 1), (4, 2)):
-        msg = f"PyInstaller v{PyInstaller.__version__} is unsupported\n"
-        msg += "(See https://github.com/JonathonReinhart/staticx/issues/170)"
-        raise Error(msg)
-
-    if pyi_version < (5, 10, 0):
-        # Adapt the CArchiveReader from PyInstaller before 5.10
-        # to the new 5.10+ API.
-        pyi_ar = CArchiveReaderPre510Adapter(pyi_ar)
+    match pyi_version:
+        case (4, 1 | 2, *_):
+            msg = f"PyInstaller v{PyInstaller.__version__} is unsupported\n"
+            msg += "(See https://github.com/JonathonReinhart/staticx/issues/170)"
+            raise Error(msg)
+        case v if v < (5, 10, 0):
+            # Adapt the CArchiveReader from PyInstaller before 5.10
+            # to the new 5.10+ API.
+            pyi_ar = CArchiveReaderPre510Adapter(pyi_ar)
 
     with PyInstallHook(sx, pyi_ar) as h:
         h.process()

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -5,11 +5,11 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from tempfile import _TemporaryFileWrapper
-from typing import cast, Any, IO, TypeVar
+from typing import cast, Any, IO, TypeVar, TypeAlias
 from .errors import DirectoryExistsError
 
 
-Pathlike = Path | str
+Pathlike: TypeAlias = Path | str
 T = TypeVar("T")
 
 def make_mode_executable(mode: int) -> int:

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -5,11 +5,11 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from tempfile import _TemporaryFileWrapper
-from typing import cast, Any, IO, Optional, TypeVar, Union
+from typing import cast, Any, IO, TypeVar
 from .errors import DirectoryExistsError
 
 
-Pathlike = Union[Path, str]
+Pathlike = Path | str
 T = TypeVar("T")
 
 def make_mode_executable(mode: int) -> int:
@@ -58,7 +58,7 @@ def is_iterable(x: object) -> bool:
     # TODO: Return typing.TypeGuard
     return isinstance(x, Iterable) and not isinstance(x, str)
 
-def coerce_sequence(x: Union[T, Iterable[T]]) -> list[T]:
+def coerce_sequence(x: T | Iterable[T]) -> list[T]:
     if is_iterable(x):
         return list(cast(Iterable, x))
     return [cast(T, x)]
@@ -70,9 +70,9 @@ _NO_DEFAULT = _Sentinel()
 
 def single(
     iterable: Iterable[T],
-    key: Optional[Callable[[T], bool]] = None,
-    default: Union[T, None, _Sentinel] = _NO_DEFAULT,
-) -> Optional[T]:
+    key: Callable[[T], bool] | None = None,
+    default: T | None | _Sentinel = _NO_DEFAULT,
+) -> T | None:
     """Returns a single item from iterable
 
     Arguments:

--- a/staticx/utils.py
+++ b/staticx/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from tempfile import _TemporaryFileWrapper
-from typing import cast, Any, IO, TypeVar, TypeAlias
+from typing import cast, Any, IO, TypeVar, TypeAlias, TypeGuard
 from .errors import DirectoryExistsError
 
 
@@ -53,14 +53,13 @@ def copy_fileobj_to_tempfile(fsrc: IO[bytes], **kwargs: Any) -> _TemporaryFileWr
     return fdst
 
 
-def is_iterable(x: object) -> bool:
+def is_iterable(x: object) -> TypeGuard[Iterable]:
     """Returns true if x is iterable but not a string"""
-    # TODO: Return typing.TypeGuard
     return isinstance(x, Iterable) and not isinstance(x, str)
 
 def coerce_sequence(x: T | Iterable[T]) -> list[T]:
     if is_iterable(x):
-        return list(cast(Iterable, x))
+        return list(x)
     return [cast(T, x)]
 
 class _Sentinel:

--- a/staticx/version.py
+++ b/staticx/version.py
@@ -1,7 +1,6 @@
 import dataclasses
 import importlib.metadata
 from pathlib import Path
-from typing import Optional
 import subprocess
 import sys
 
@@ -28,7 +27,7 @@ class GitDescribe:
     rev: str
 
 
-def git_describe() -> Optional[GitDescribe]:
+def git_describe() -> GitDescribe | None:
     # Get the version from the local Git repository
     try:
         subprocess.run(["git", "update-index", "-q", "--refresh"], check=True, cwd=PROJPATH)

--- a/stubs/elftools/elf/elffile.pyi
+++ b/stubs/elftools/elf/elffile.pyi
@@ -1,7 +1,9 @@
 from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, BinaryIO
-from typing_extensions import Literal, Self, TypeAlias
+from typing import Any, BinaryIO, Literal, TypeAlias
+from typing_extensions import (
+    Self,  # Python 3.11
+)
 from types import TracebackType
 
 #from ..construct import Struct

--- a/stubs/elftools/elf/elffile.pyi
+++ b/stubs/elftools/elf/elffile.pyi
@@ -1,6 +1,6 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, BinaryIO, Iterable
+from typing import Any, BinaryIO
 from typing_extensions import Literal, Self, TypeAlias
 from types import TracebackType
 

--- a/stubs/elftools/elf/gnuversions.pyi
+++ b/stubs/elftools/elf/gnuversions.pyi
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from typing import Optional
 from .sections import Section
 
 class Version:
@@ -20,5 +19,5 @@ class GNUVerNeedSection(GNUVersionSection):
         ...
     def iter_versions(self) -> Iterable[tuple[Version, Iterable[VersionAuxiliary]]]:
         ...
-    def get_version(self, index: int) -> Optional[tuple[Version, VersionAuxiliary]]:
+    def get_version(self, index: int) -> tuple[Version, VersionAuxiliary] | None:
         ...

--- a/stubs/elftools/elf/gnuversions.pyi
+++ b/stubs/elftools/elf/gnuversions.pyi
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Optional, Tuple
+from typing import Optional
 from .sections import Section
 
 class Version:
@@ -11,14 +11,14 @@ class VersionAuxiliary:
 class GNUVersionSection(Section):
     def num_versions(self) -> int:
         ...
-    def iter_versions(self) -> Iterable[Tuple[Version, Iterable[VersionAuxiliary]]]:
+    def iter_versions(self) -> Iterable[tuple[Version, Iterable[VersionAuxiliary]]]:
         ...
 
 
 class GNUVerNeedSection(GNUVersionSection):
     def has_indexes(self) -> bool:
         ...
-    def iter_versions(self) -> Iterable[Tuple[Version, Iterable[VersionAuxiliary]]]:
+    def iter_versions(self) -> Iterable[tuple[Version, Iterable[VersionAuxiliary]]]:
         ...
-    def get_version(self, index: int) -> Optional[Tuple[Version, VersionAuxiliary]]:
+    def get_version(self, index: int) -> Optional[tuple[Version, VersionAuxiliary]]:
         ...

--- a/stubs/elftools/elf/gnuversions.pyi
+++ b/stubs/elftools/elf/gnuversions.pyi
@@ -1,4 +1,5 @@
-from typing import Iterable, Optional, Tuple
+from collections.abc import Iterable
+from typing import Optional, Tuple
 from .sections import Section
 
 class Version:

--- a/test/pyinstall-lib-runpath/app.py
+++ b/test/pyinstall-lib-runpath/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from ctypes import *
+from ctypes import CDLL, c_int
 from pathlib import Path
 
 mydir = Path(__file__).parent


### PR DESCRIPTION
With support for Python 3.9 dropped (#303), leverage the following Python 3.10 features:

* **PEP 604 Union Types:** Replaced all occurrences of `typing.Union[X, Y]` and `typing.Optional[X]` with the more concise `X | Y` and `X | None` syntax.
* **Type Aliases:** Updated type definitions to use `typing.TypeAlias` for better clarity and explicit intent.
* **Structural Pattern Matching:** Refactored version-based logic in the PyInstaller hook and architecture-based checks in the BCJ filter to use `match` and `case` statements.
* **TypeGuard:** Addressed a "TODO" in staticx/utils.py by implementing `typing.TypeGuard` for the `is_iterable` function, improving type inference for the type checker.
* **Type Safety:** Removed redundant type casts that are no longer necessary with the improved type narrowing provided by TypeGuard.