### PR TITLE
setup.py Update bdist_wheel import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.command.build import build
 from subprocess import check_call
 
 from setuptools import Command, find_packages, setup
-from wheel.bdist_wheel import bdist_wheel
+from setuptools.command.bdist_wheel import bdist_wheel
 
 ################################################################################
 # Dynamic versioning


### PR DESCRIPTION
setuptools.command.bdist_wheel is now the canonical home of this command.

Verified that our hook works, and the resulting wheel contains '-py3-none-manylinux1_x86_64.whl' in its name.

Fixes #310